### PR TITLE
Sort team standings by losses and then wins if win percentage is equal

### DIFF
--- a/js/core/team.js
+++ b/js/core/team.js
@@ -513,7 +513,7 @@ define(["db", "globals", "core/player", "lib/underscore", "util/helpers", "util/
 
         tx = db.getObjectStore(options.ot, ["players", "releasedPlayers", "teams"], null);
         tx.objectStore("teams").getAll(options.tid).onsuccess = function (event) {
-            var ft, fts, i, returnOneTeam, savePayroll, t;
+            var ft, fts, i, returnOneTeam, savePayroll, t, sortBy;
 
             t = event.target.result;
 
@@ -533,9 +533,22 @@ define(["db", "globals", "core/player", "lib/underscore", "util/helpers", "util/
                 fts.push(ft);
             }
 
-            if (options.sortBy === "winp") {
+            if (Array.isArray(options.sortBy)) {
+                // Sort by multiple properties
+                sortBy = options.sortBy.slice();
+                fts.sort(function (a, b) {
+                    for(i=0;i<sortBy.length;i++) {
+                        var prop = sortBy[i],
+                            result = (prop.indexOf("-") === 1) ? a[sortBy[i]] - b[sortBy[i]] : b[sortBy[i]] - a[sortBy[i]];
+
+                        if(result || i === sortBy.length - 1) {
+                            return result;
+                        }
+                    }
+                });
+            } else if (options.sortBy === "winp") {
                 // Sort by winning percentage, descending
-                fts.sort(function (a, b) {  return b.winp - a.winp; });
+                fts.sort(function (a, b) { return b.winp - a.winp; });
             }
 
             // If payroll for the current season was requested, find the current payroll for each team. Otherwise, don't.

--- a/js/views/leagueDashboard.js
+++ b/js/views/leagueDashboard.js
@@ -74,7 +74,7 @@ define(["db", "globals", "ui", "core/player", "core/season", "core/team", "lib/j
                 seasonAttrs: ["won", "lost", "winp", "streakLong", "att", "revenue", "profit"],
                 stats: stats,
                 season: g.season,
-                sortBy: "winp"
+                sortBy: ["winp", "-lost", "won"]
             }, function (teams) {
                 var cid, i, j, ranks;
 

--- a/js/views/playoffs.js
+++ b/js/views/playoffs.js
@@ -23,7 +23,7 @@ define(["globals", "ui", "core/season", "core/team", "lib/jquery", "lib/knockout
                     attrs: ["tid", "cid", "abbrev", "name"],
                     seasonAttrs: ["winp"],
                     season: inputs.season,
-                    sortBy: "winp"
+                    sortBy: ["winp", "-lost", "won"]
                 }, function (teams) {
                     var cid, i, j, keys, series, teamsConf;
 

--- a/js/views/standings.js
+++ b/js/views/standings.js
@@ -57,7 +57,7 @@ define(["globals", "ui", "core/team", "lib/jquery", "lib/knockout", "lib/knockou
                 attrs: ["tid", "cid", "did", "abbrev", "region", "name"],
                 seasonAttrs: ["won", "lost", "winp", "wonHome", "lostHome", "wonAway", "lostAway", "wonDiv", "lostDiv", "wonConf", "lostConf", "lastTen", "streak"],
                 season: inputs.season,
-                sortBy: "winp"
+                sortBy: ["winp", "-lost", "won"]
             }, function (teams) {
                 var confs, confTeams, data, divTeams, i, j, k, l, lastTenLost, lastTenWon;
 


### PR DESCRIPTION
In the first league I started, my team began the season 8-0 and a division rival started 7-0, yet they were listed as first in the division and I was listed as 2nd, being -0.5 games behind. So I updated the team sorting to sort by win percentage, losses and wins, in that order, to try and resolve ties. 

It could then take into account additional factors in the case of a tie, like division/conference/head-to-head record, etc. But I stopped at the first three properties for now.
