### PR TITLE
Reversed the ordering of coach modulation in base change calculation. 

### DIFF
--- a/js/core/player.js
+++ b/js/core/player.js
@@ -268,7 +268,7 @@ define(["globals", "core/finances", "data/injuries", "data/names", "lib/faces", 
             }
 
             // Modulate by coaching
-            baseChange *= ((coachingRank - 1) * 0.5 / 29 + 0.75);
+            baseChange *= ((coachingRank - 1) * (-0.5) / 29 + 1.25);
 
             ratingKeys = ['stre', 'spd', 'jmp', 'endu', 'ins', 'dnk', 'ft', 'fg', 'tp', 'blk', 'stl', 'drb', 'pss', 'reb'];
             for (j = 0; j < ratingKeys.length; j++) {


### PR DESCRIPTION
So, the basic idea of the coaching modulation during every off-season is that better coaching (lower rank) should give higher base change, right?

Except the way the code is right now, you have it set that rank is in descending order. The &#35; 1 coaching team pays the most money, and &#35; 30 pays the least.

The code in `jdscheff:master` looks like this: `baseChange *= ((coachingRank - 1) * 0.5 / 29 + 0.75);`

Notice how if I have the best coaching in the League, then my coachingRank (being &#35; 1) will zero out the first term, and then my base change will actually **drop** by 25% because the equation becomes `baseChange *= 0.75`.

Conversely, if my coachingRank is &#35; 30, then the first term simplifies to 0.5, and added to 0.75, indicates that my base change on all my players will increase by 25% if I literally pay zero money into my coaching staff.

I'm pretty sure this is backwards, unless your comment in line 213 (coachingRank From 1 to 30, where 1 is best coaching staff and 30 is worst. Default is 15.5) is completely wrong and we've all been playing incorrectly! 
