### PR TITLE
Add grace period before firing user

### DIFF
--- a/js/util/message.js
+++ b/js/util/message.js
@@ -204,6 +204,16 @@ define(["db", "globals", "ui", "util/random"], function (db, g, ui, random) {
                     "<p>" + random.choice(wins[indWins]) + " " + random.choice(playoffs[indPlayoffs]) + "</p>" +
                     "<p>" + random.choice(money[indMoney]) + "</p>" +
                     "<p>" + random.choice(ovr[indOvr]).replace("{{activity}}", activity2) + "</p>";
+            } else if ((g.season - g.startingSeason) < 3) {
+                if (g.ownerMood.wins < 0 && g.ownerMood.playoffs < 0 && g.ownerMood.money < 0) {
+                    m = "<p>What the hell did you do to my franchise?! I'd fire you, but I can't find anyone who wants to clean up your mess.</p>"
+                } else if (g.ownerMood.money < 0 && g.ownerMood.wins >= 0 && g.ownerMood.playoffs >= 0) {
+                    m = "<p>I don't care what our colors are. I need to see some green! I won't wait forever. MAKE ME MONEY.</p>"
+                } else if (g.ownerMood.money >= 0 && g.ownerMood.wins < 0 && g.ownderMood.playoffs < 0) {
+                    m = "<p>Our fans are out for blood. Put a winning team together, or I'll let those animals have you.</p>"
+                } else {
+                    m = "<p>The longer you keep your job, the more I question why I hired you. Do better or get out.</p>"
+                }
             } else {
                 if (g.ownerMood.wins < 0 && g.ownerMood.playoffs < 0 && g.ownerMood.money < 0) {
                     m = "<p>You've been an all-around disappointment. You're fired.</p>";
@@ -226,6 +236,8 @@ define(["db", "globals", "ui", "util/random"], function (db, g, ui, random) {
         });
         tx.oncomplete = function () {
             if (ownerMoodSum > -1) {
+                cb();
+            } else if ((g.season - g.startingSeason) < 3) {
                 cb();
             } else {
                 db.setGameAttributes({gameOver: true}, cb);


### PR DESCRIPTION
### Summary

This PR creates a three season grace period to begin a new league in which the user cannot be fired. Three seasons seems like the best fit for a balance of realism and game play. Coaches typically get two seasons before their owners will consider firing them, and GMs seem to have an even larger window.

I've also added four owner messages indicating that the user would have been fired if not for the grace period. I tried to match these up to the fire messages in both style and indication of necessary improvement.
#### So the flow is...

2013: Random message
2014: Normal message or grace period message
2015: Normal message or grace period message
2016: Normal message or fired
