### PR TITLE
Fix to prevent sorting on column that is essentially unsortable

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -217,9 +217,9 @@ define(["db", "globals", "templates", "lib/davis", "lib/jquery", "lib/knockout",
         table.dataTable(options);
     }
     function datatableSinglePage(table, sort_col, data, extraOptions) {
-	var options;
+        var options;
 
-	options = $.extend({
+        options = $.extend({
             aaData: data,
             aaSorting: [[sort_col, "desc"]],
             bDestroy: true,
@@ -233,9 +233,9 @@ define(["db", "globals", "templates", "lib/davis", "lib/jquery", "lib/knockout",
             fnStateLoad: function (oSettings) {
                 return JSON.parse(localStorage.getItem("DataTables_" + table[0].id));
             }
-        }, extraOptions);
+         }, extraOptions);
 	
-        table.dataTable(options);
+         table.dataTable(options);
     }
 
     // For dropdown menus to change team/season/whatever

--- a/js/views/trade.js
+++ b/js/views/trade.js
@@ -354,12 +354,12 @@ define(["globals", "ui", "core/player", "core/trade", "lib/davis", "lib/jquery",
 
         ko.computed(function () {
             ui.datatableSinglePage($("#roster-user"), 5, tradeable("user", vm.userRoster()),
-				   {"aoColumnDefs" : [ { 'bSortable' : false, 'aTargets' : [ 0 ] } ] });
+                                   {aoColumnDefs: [{bSortable: false, aTargets: [0]}]});
         }).extend({throttle: 1});
 
         ko.computed(function () {
             ui.datatableSinglePage($("#roster-other"), 5, tradeable("other", vm.otherRoster()),
-				   {"aoColumnDefs" : [ { 'bSortable' : false, 'aTargets' : [ 0 ] } ] });
+                                   {aoColumnDefs: [{bSortable: false, aTargets: [0]}]});
         }).extend({throttle: 1});
     }
 


### PR DESCRIPTION
I noticed that on the trade screen the column for the checkmarks has sort controls at in the table headers even though these sort controls don't do anything.

I looked around for the way to disable sorting in the jQuery datatable plugin and this seems to work.  I had to modify your datatableSinglePage function to allow it to receive extraOptions just like your datatable function.

This is my first pull request on github and my first time contributing to an open source project.  Please let me know if I'm following procedures incorrectly or something!
