### PR TITLE
Fix to show no team for retired players on the draft summary

### DIFF
--- a/js/views/draftSummary.js
+++ b/js/views/draftSummary.js
@@ -63,7 +63,7 @@ define(["globals", "ui", "core/player", "lib/jquery", "lib/knockout", "lib/under
 
                 if (pa.draft.round === 1 || pa.draft.round === 2) {
                     // Attributes
-                    p = {pid: pa.pid, name: pa.name, pos: pa.pos, draft: pa.draft, currentAge: pa.age, currentAbbrev: pa.abbrev};
+                    p = {pid: pa.pid, name: pa.name, pos: pa.pos, draft: pa.draft, currentAge: pa.age};
 
                     // Ratings
                     currentPr = _.last(pa.ratings);
@@ -71,10 +71,12 @@ define(["globals", "ui", "core/player", "lib/jquery", "lib/knockout", "lib/under
                         p.currentOvr = currentPr.ovr;
                         p.currentPot = currentPr.pot;
                         p.currentSkills = currentPr.skills;
+                        p.currentAbbrev = pa.abbrev;
                     } else {
                         p.currentOvr = "";
                         p.currentPot = "";
                         p.currentSkills = "";
+                        p.currentAbbrev = "";
                     }
 
                     // Stats


### PR DESCRIPTION
I noticed that on the draft summary page, retired players show as the users team in the Current Team column.  This fix is to not show anything for retired players.

I'm not 100% sure if this fix is ideal... is it a bug that the database things currentAbbrev has a value for retired players?
