### PR TITLE
Top 100 Players Pyramid

### DIFF
--- a/src/js/common/types.js
+++ b/src/js/common/types.js
@@ -478,6 +478,7 @@ export type PlayerWithoutPid = {
     watch: boolean,
     weight: number,
     yearsFreeAgent: number,
+    hofScore: number
 };
 
 export type Player = PlayerWithoutPid & {pid: number};

--- a/src/js/ui/components/LeagueWrapper.js
+++ b/src/js/ui/components/LeagueWrapper.js
@@ -68,6 +68,9 @@ class SideMenu extends React.Component {
                 <li className={pageId === 'hallOfFame' ? 'active' : null}>
                     <a href={helpers.leagueUrl(['hall_of_fame'])}>Hall of Fame</a>
                 </li>
+                <li className={pageId === 'pyramid' ? 'active' : null}>
+                    <a href={helpers.leagueUrl(['pyramid'])}>Pyramid</a>
+                </li>
                 <li className="bs-navheader">Stats</li>
                 <li className={pageId === 'gameLog' ? 'active' : null}>
                     <a href={helpers.leagueUrl(['game_log'])}>Game Log</a>

--- a/src/js/ui/index.js
+++ b/src/js/ui/index.js
@@ -106,6 +106,7 @@ const genPage = (id, inLeague = true) => {
     page('/l/:lid/history', genPage('history'));
     page('/l/:lid/history/:season', genPage('history'));
     page('/l/:lid/hall_of_fame', genPage('hallOfFame'));
+    page('/l/:lid/pyramid', genPage('pyramid'));
     page('/l/:lid/edit_team_info', genPage('editTeamInfo'));
     page('/l/:lid/roster', genPage('roster'));
     page('/l/:lid/roster/:abbrev', genPage('roster'));

--- a/src/js/ui/util/getCols.js
+++ b/src/js/ui/util/getCols.js
@@ -300,6 +300,10 @@ const cols: {
         desc: 'Rookie of the Year',
         sortType: 'name',
     },
+    'Rank': {
+      desc: 'Pyramid Rank',
+      sortType: 'number'
+    },
     'Reb': {
         desc: 'Rebounds Per Game',
         sortSequence: ['desc', 'asc'],
@@ -314,6 +318,12 @@ const cols: {
         sortType: 'currency',
     },
     'Runner Up': {},
+    'Score':
+    {
+      desc: 'Pyrmaid Score',
+      sortSequence: ['desc', 'asc'],
+      sortType: 'number'
+    },
     'SMOY': {
         desc: 'Sixth Man of the Year',
         sortType: 'name',

--- a/src/js/ui/views/Player.js
+++ b/src/js/ui/views/Player.js
@@ -290,6 +290,7 @@ const Player = ({events, feats, freeAgent, godMode, injured, player, retired, sh
                 <div className="player-picture">
                     <PlayerPicture face={player.face} imgURL={player.imgURL} />
                 </div>
+                <div></div>
                 <div style={{float: 'left'}}>
                     <strong>{player.ratings[player.ratings.length - 1].pos}, {player.teamRegion} {player.teamName}</strong><br />
                     Height: {player.hgtFt}'{player.hgtIn}"<br />
@@ -301,6 +302,7 @@ const Player = ({events, feats, freeAgent, godMode, injured, player, retired, sh
                     {contractInfo}
                     {godMode ? <div><a href={helpers.leagueUrl(['customize_player', player.pid])} className="god-mode god-mode-text">Edit Player</a><br /></div> : null}
                     {statusInfo}
+                    Legacy Score: {player.hofScore > 0 ? <div>{player.hofScore.toFixed(2)}</div> : <div>None</div>}
                 </div>
             </div>
 
@@ -310,7 +312,6 @@ const Player = ({events, feats, freeAgent, godMode, injured, player, retired, sh
                 {!retired ? <RatingsOverview ratings={player.ratings} /> : null}
             </div>
         </div>
-
         <p />
 
         {showTradeFor ? <span title={player.untradableMsg}>
@@ -356,6 +357,7 @@ const Player = ({events, feats, freeAgent, godMode, injured, player, retired, sh
         />
 
         <h2>Ratings</h2>
+        <div>HOF Score: {player.hofScore}</div>
         <DataTable
             cols={getCols('Year', 'Team', 'Age', 'Pos', 'Ovr', 'Pot', 'rating:Hgt', 'rating:Str', 'rating:Spd', 'rating:Jmp', 'rating:End', 'rating:Ins', 'rating:Dnk', 'rating:FT', 'rating:2Pt', 'rating:3Pt', 'rating:Blk', 'rating:Stl', 'rating:Drb', 'rating:Pss', 'rating:Reb', 'Skills')}
             defaultSort={[0, 'asc']}

--- a/src/js/ui/views/Player.js
+++ b/src/js/ui/views/Player.js
@@ -302,7 +302,7 @@ const Player = ({events, feats, freeAgent, godMode, injured, player, retired, sh
                     {contractInfo}
                     {godMode ? <div><a href={helpers.leagueUrl(['customize_player', player.pid])} className="god-mode god-mode-text">Edit Player</a><br /></div> : null}
                     {statusInfo}
-                    <div>Pyramid Score: {player.hofScore > 0 ? {player.hofScore.toFixed(2)}</div> : 'None'}</div>
+                    <div>Pyramid Score: {player.hofScore > 0 ? `${player.hofScore.toFixed(2)}` : 'None'}</div>
                 </div>
             </div>
 

--- a/src/js/ui/views/Player.js
+++ b/src/js/ui/views/Player.js
@@ -302,7 +302,7 @@ const Player = ({events, feats, freeAgent, godMode, injured, player, retired, sh
                     {contractInfo}
                     {godMode ? <div><a href={helpers.leagueUrl(['customize_player', player.pid])} className="god-mode god-mode-text">Edit Player</a><br /></div> : null}
                     {statusInfo}
-                    Legacy Score: {player.hofScore > 0 ? <div>{player.hofScore.toFixed(2)}</div> : <div>None</div>}
+                    <div>Pyramid Score: {player.hofScore > 0 ? {player.hofScore.toFixed(2)}</div> : 'None'}</div>
                 </div>
             </div>
 

--- a/src/js/ui/views/Pyramid.js
+++ b/src/js/ui/views/Pyramid.js
@@ -1,0 +1,84 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {g, helpers} from '../../common';
+import {getCols, setTitle} from '../util';
+import {DataTable, NewWindowLink} from '../components';
+
+const Pyramid = ({players}) => {
+    setTitle('Pyramid');
+
+    const superCols = [{
+        title: '',
+        colspan: 6,
+    }, {
+        title: 'Best Season',
+        colspan: 8,
+    }, {
+        title: 'Career Stats',
+        colspan: 7,
+    }, {
+      title: 'Pyramid',
+      colspan: 2
+    }];
+
+    const cols = getCols('Name', 'Pos', 'Drafted', 'Retired', 'Pick', 'Peak Ovr', 'Year', 'Team', 'GP', 'Min', 'PPG', 'Reb', 'Ast', 'PER', 'GP', 'Min', 'PPG', 'Reb', 'Ast', 'PER', 'EWA', 'Score', 'Rank');
+
+    const rows = players.map(p => {
+        return {
+            key: p.pid,
+            data: [
+                <a href={helpers.leagueUrl(["player", p.pid])}>{p.name}</a>,
+                p.ratings[p.ratings.length - 1].pos,
+                p.draft.year,
+                p.retiredYear !== Infinity ? p.retiredYear : '',
+                p.draft.round > 0 ? `${p.draft.round}-${p.draft.pick}` : '',
+                p.peakOvr,
+                p.bestStats.season,
+                <a href={helpers.leagueUrl(["roster", p.bestStats.abbrev, p.bestStats.season])}>{p.bestStats.abbrev}</a>,
+                p.bestStats.gp,
+                p.bestStats.min.toFixed(1),
+                p.bestStats.pts.toFixed(1),
+                p.bestStats.trb.toFixed(1),
+                p.bestStats.ast.toFixed(1),
+                p.bestStats.per.toFixed(1),
+                p.careerStats.gp,
+                p.careerStats.min.toFixed(1),
+                p.careerStats.pts.toFixed(1),
+                p.careerStats.trb.toFixed(1),
+                p.careerStats.ast.toFixed(1),
+                p.careerStats.per.toFixed(1),
+                p.careerStats.ewa.toFixed(1),
+                p.hofScore.toFixed(2),
+                players.indexOf(p)+1
+            ],
+            classNames: {
+                danger: p.legacyTid === g.userTid,
+                info: p.statsTids.slice(0, p.statsTids.length - 1).includes(g.userTid) && p.legacyTid !== g.userTid,
+                success: p.statsTids[p.statsTids.length - 1] === g.userTid && p.legacyTid !== g.userTid,
+            },
+        };
+    });
+
+    return <div>
+        <h1>Pyramid <NewWindowLink /></h1>
+
+        <p>This is ranking of the league's Top 100 players ever. Only active players and players in the Hall of Fame are included.</p>
+        <p>The formula for ranking is very similar to <a href="http://espn.go.com/nba/story/_/id/8736873/nba-experts-rebuild-springfield-hall-fame-espn-magazine">the method described in this article</a>.</p>
+        <p>Players who have played for your team are <span className="text-info">highlighted in blue</span>. Players who retired or are active with your team are <span className="text-success">highlighted in green</span>. Players who played most of their career with your team are <span className="text-danger">highlighted in red</span>.</p>
+
+        <DataTable
+            cols={cols}
+            defaultSort={[20, 'desc']}
+            name="HallOfFame"
+            pagination
+            rows={rows}
+            superCols={superCols}
+        />
+    </div>;
+};
+
+Pyramid.propTypes = {
+    players: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default Pyramid;

--- a/src/js/ui/views/index.js
+++ b/src/js/ui/views/index.js
@@ -46,6 +46,7 @@ export {default as PlayerStatDists} from './PlayerStatDists';
 export {default as PlayerStats} from './PlayerStats';
 export {default as Playoffs} from './Playoffs';
 export {default as PowerRankings} from './PowerRankings';
+export {default as Pyramid} from './Pyramid';
 export {default as ResetPassword} from './ResetPassword';
 export {default as Roster} from './Roster';
 export {default as Schedule} from './Schedule';

--- a/src/js/worker/core/phase.js
+++ b/src/js/worker/core/phase.js
@@ -122,6 +122,7 @@ async function newPhasePreseason(conditions: Conditions) {
     for (const p of players) {
         // Update ratings
         player.addRatingsRow(p, scoutingRank);
+        p.stats = await idb.cache.playerStats.indexGetAll('playerStatsAllByPid', p.pid);
         player.develop(p, 1, false, coachingRanks[p.tid]);
 
         // Update player values after ratings changes

--- a/src/js/worker/core/phase.js
+++ b/src/js/worker/core/phase.js
@@ -319,6 +319,8 @@ async function newPhaseBeforeDraft(conditions: Conditions, liveGameSim?: boolean
         // Get player stats, used for HOF calculation
         const playerStats = await idb.getCopies.playerStats({pid: p.pid});
 
+        p.hofScore = player.hofScore(p,playerStats);
+
         const age = g.season - p.born.year;
         const pot = p.ratings[p.ratings.length - 1].pot;
 

--- a/src/js/worker/core/player.js
+++ b/src/js/worker/core/player.js
@@ -379,7 +379,7 @@ function calcBaseChange(age: number, potentialDifference: number): number {
  * @return {Object} Updated player object.
  */
 function develop(
-    p: {born: {loc: string, year: number}, pos?: string, ratings: PlayerRatings[]},
+    p: {born: {loc: string, year: number}, pos?: string, ratings: PlayerRatings[], hofScore: number, stats: PlayerStats[]},
     years?: number = 1,
     newPlayer?: boolean = false,
     coachingRank?: number = 15.5,
@@ -477,6 +477,8 @@ function develop(
     } else {
         p.ratings[r].pos = pos(p.ratings[r]);
     }
+
+    p.hofScore = hofScore(p, p.stats);
 }
 
 /**
@@ -949,6 +951,7 @@ function generate(
         valueFuzz: 0,
         valueNoPotFuzz: 0,
         valueWithContract: 0,
+        stats: []
     };
 
     const rand = Math.random();
@@ -1006,6 +1009,22 @@ function contractSeasonsRemaining(exp: number, numGamesRemaining: number): numbe
  * @return {boolean} Hall of Fame worthy?
  */
 function madeHof(p: Player, playerStats: PlayerStats[]): boolean {
+
+        return hofScore(p, playerStats) > 100;
+
+}
+
+/**
+ * Is a player worthy of the Hall of Fame?
+ *
+ * This calculation is based on http://espn.go.com/nba/story/_/id/8736873/nba-experts-rebuild-springfield-hall-fame-espn-magazine except it uses PER-based estimates of wins added http://insider.espn.go.com/nba/hollinger/statistics (since PER is already calculated for each season) and it includes each playoff run as a separate season.
+ *
+ * @memberOf core.player
+ * @param {Object} p Player object.
+ * @return {number} Hall of Fame score
+ */
+function hofScore(p: Player, playerStats: PlayerStats[]): number {
+
     const mins = playerStats.map(ps => ps.min);
     const pers = playerStats.map(ps => ps.per);
 
@@ -1048,8 +1067,9 @@ function madeHof(p: Player, playerStats: PlayerStats[]): boolean {
     }
 
     // Final formula
-    return ewa + df > 100;
+    return ewa + df;
 }
+
 
 type ValueOptions = {
     fuzz?: boolean,
@@ -1227,6 +1247,8 @@ function retire(p: Player, playerStats: PlayerStats[], conditions: Conditions, r
 
     p.tid = PLAYER.RETIRED;
     p.retiredYear = g.season;
+
+    p.hofScore = hofScore(p, playerStats);
 
     // Add to Hall of Fame?
     if (madeHof(p, playerStats)) {
@@ -1572,6 +1594,7 @@ export default {
     release,
     skills,
     madeHof,
+    hofScore,
     updateValues,
     retire,
     name,

--- a/src/js/worker/core/player.js
+++ b/src/js/worker/core/player.js
@@ -477,8 +477,6 @@ function develop(
     } else {
         p.ratings[r].pos = pos(p.ratings[r]);
     }
-
-    p.hofScore = hofScore(p, p.stats);
 }
 
 /**
@@ -1246,9 +1244,7 @@ function retire(p: Player, playerStats: PlayerStats[], conditions: Conditions, r
     }
 
     p.tid = PLAYER.RETIRED;
-    p.retiredYear = g.season;
-
-    p.hofScore = hofScore(p, playerStats);
+    p.retiredYear = g.season;    
 
     // Add to Hall of Fame?
     if (madeHof(p, playerStats)) {

--- a/src/js/worker/views/index.js
+++ b/src/js/worker/views/index.js
@@ -46,6 +46,7 @@ export {default as playerStatDists} from './playerStatDists';
 export {default as playerStats} from './playerStats';
 export {default as playoffs} from './playoffs';
 export {default as powerRankings} from './powerRankings';
+export {default as pyramid} from './pyramid';
 export {default as resetPassword} from './resetPassword';
 export {default as roster} from './roster';
 export {default as schedule} from './schedule';

--- a/src/js/worker/views/player.js
+++ b/src/js/worker/views/player.js
@@ -14,7 +14,7 @@ async function updatePlayer(
         let p = await idb.getCopy.players({pid: inputs.pid});
         if (p === undefined) { throw new Error('Invalid player ID'); }
         p = await idb.getCopy.playersPlus(p, {
-            attrs: ["pid", "name", "tid", "abbrev", "teamRegion", "teamName", "age", "hgtFt", "hgtIn", "weight", "born", "diedYear", "contract", "draft", "face", "mood", "injury", "salaries", "salariesTotal", "awardsGrouped", "freeAgentMood", "imgURL", "watch", "gamesUntilTradable", "college"],
+            attrs: ["pid", "name", "tid", "abbrev", "teamRegion", "teamName", "age", "hgtFt", "hgtIn", "weight", "born", "diedYear", "contract", "draft", "face", "mood", "injury", "salaries", "salariesTotal", "awardsGrouped", "freeAgentMood", "imgURL", "watch", "gamesUntilTradable", "college", "hofScore"],
             ratings: ["season", "abbrev", "age", "ovr", "pot", "hgt", "stre", "spd", "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl", "drb", "pss", "reb", "skills", "pos"],
             stats: ["psid", "season", "tid", "abbrev", "age", "gp", "gs", "min", "fg", "fga", "fgp", "fgAtRim", "fgaAtRim", "fgpAtRim", "fgLowPost", "fgaLowPost", "fgpLowPost", "fgMidRange", "fgaMidRange", "fgpMidRange", "tp", "tpa", "tpp", "ft", "fta", "ftp", "pm", "orb", "drb", "trb", "ast", "tov", "stl", "blk", "ba", "pf", "pts", "per", "ewa"],
             playoffs: true,
@@ -22,7 +22,7 @@ async function updatePlayer(
             fuzz: true,
         });
         if (p === undefined) { throw new Error('Invalid player ID'); }
-
+        
         // Account for extra free agent demands
         if (p.tid === PLAYER.FREE_AGENT) {
             p.contract.amount = freeAgents.amountWithMood(p.contract.amount, p.freeAgentMood[g.userTid]);

--- a/src/js/worker/views/pyramid.js
+++ b/src/js/worker/views/pyramid.js
@@ -1,0 +1,60 @@
+// @flow
+
+import {PHASE, PLAYER, g} from '../../common';
+import {idb} from '../db';
+import type {GetOutput, UpdateEvents} from '../../common/types';
+
+async function updatePlayers(
+    inputs: GetOutput,
+    updateEvents: UpdateEvents,
+): void | {[key: string]: any} {
+    if (updateEvents.includes('firstRun') || (updateEvents.includes('newPhase') && g.phase === PHASE.BEFORE_DRAFT)) {
+        let players = await idb.getCopies.players();
+        players = players.filter(p => p.hof || p.tid !== PLAYER.RETIRED);
+        players = await idb.getCopies.playersPlus(players, {
+            attrs: ["pid", "name", "draft", "retiredYear", "statsTids", "hofScore"],
+            ratings: ["ovr", "pos"],
+            stats: ["season", "abbrev", "tid", "gp", "min", "trb", "ast", "pts", "per", "ewa"],
+            fuzz: true,
+        });
+
+        players.sort((a, b) => b.hofScore - a.hofScore);
+        players = players.slice(0,100);
+
+        // This stuff isn't in idb.getCopies.playersPlus because it's only used here.
+        for (const p of players) {
+            p.peakOvr = 0;
+            for (const pr of p.ratings) {
+                if (pr.ovr > p.peakOvr) {
+                    p.peakOvr = pr.ovr;
+                }
+            }
+
+            p.bestStats = {};
+            let bestEWA = 0;
+            p.teamSums = {};
+            for (let j = 0; j < p.stats.length; j++) {
+                const tid = p.stats[j].tid;
+                const EWA = p.stats[j].ewa;
+                if (EWA > bestEWA) {
+                    p.bestStats = p.stats[j];
+                    bestEWA = EWA;
+                }
+                if (p.teamSums.hasOwnProperty(tid)) {
+                    p.teamSums[tid] += EWA;
+                } else {
+                    p.teamSums[tid] = EWA;
+                }
+            }
+            p.legacyTid = parseInt(Object.keys(p.teamSums).reduce((teamA, teamB) => (p.teamSums[teamA] > p.teamSums[teamB] ? teamA : teamB)), 10);
+        }
+
+        return {
+            players,
+        };
+    }
+}
+
+export default {
+    runBefore: [updatePlayers],
+};


### PR DESCRIPTION
_Note: This is my first attempt to contribute to the basketball-gm code. I don't reasonably expect this to be merged into production, but I created it as an experiment, and to get some feedback from dumbmatter and other developers_

## SUMMARY

Add a page ranking the top 100 players in the league's history, similar to Bill Simmons' [_Book of Basketball_](http://www.basketball-reference.com/awards/simmons_pyramid.html) pyramid

## OVERVIEW

* Add an attribute to the player type to track pyramid score ('hofScore') -- _note: this functionality could be implemented without adding to a data type, but that was the first implementation I put together_
* Refactor HOF calculation into a score calculator that returns a number, plus a bool that returns whether that number is > 100
* Add view for Pyramid page
* Update the league wrapper and column builder
* Add Pyramid score to player page
* Add logic to recalculate pyramid score each offseaseon

## ISSUES
* Early on, there's lots of bad/meaningless data, including lots of negative scores, though these could easily be masked as 0.
* Currently saved as data when it could be calculated on the fly.