### PR TITLE
Show shot distance on deep shots

### DIFF
--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -1338,13 +1338,34 @@ class GameSim {
 			probMake = shootingThreePointerScaled * 0.3 + 0.36;
 			probAndOne = 0.01;
 
-			// Better shooting in the ASG, why not?
+			let meanDistance = 26;
+			let distanceDeviation = 1.5;
+			// Great shooters shoot from deeper ranges
+			const threePointAbility =
+				this.team[this.o].player[p].compositeRating.shootingThreePointer * 100;
+			if (threePointAbility > 0.69) {
+				meanDistance += threePointAbility / 40;
+				distanceDeviation += threePointAbility / 80;
+			}
+
+			// Better and deeper shooting in the ASG, why not?
 			if (this.allStarGame) {
 				probMake += 0.02;
+				meanDistance += 1;
+				distanceDeviation += 0.5;
 			}
 			probMake *= g.get("threePointAccuracyFactor");
 
-			this.recordPlay("fgaTp", this.o, [this.team[this.o].player[p].name]);
+			const shotDistance = helpers.bound(
+				Math.round(random.gauss(meanDistance, distanceDeviation)),
+				24,
+				94,
+			);
+
+			this.recordPlay("fgaTp", this.o, [
+				this.team[this.o].player[p].name,
+				shotDistance,
+			]);
 		} else {
 			const r1 =
 				0.8 *
@@ -2055,11 +2076,6 @@ class GameSim {
 			const threePointerText = g.get("threePointers")
 				? "three pointer"
 				: "deep shot";
-			const threePointDistance = helpers.bound(
-				Math.round(random.gauss(26.1, 1.5)),
-				24,
-				94,
-			);
 
 			let showScore = false;
 			if (type === "injury") {
@@ -2075,9 +2091,7 @@ class GameSim {
 			} else if (type === "fgaMidRange") {
 				texts = ["{0} attempts a mid-range shot"];
 			} else if (type === "fgaTp") {
-				texts = [
-					`{0} attempts a ${threePointerText} from ${threePointDistance} feet`,
-				];
+				texts = [`{0} attempts a ${threePointerText} from {1} feet`];
 			} else if (type === "fgAtRim") {
 				// Randomly pick a name to be dunked on
 				const ratios = this.ratingArray("blocking", this.d, 5);

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -1366,9 +1366,7 @@ class GameSim {
 				94,
 			);
 			const distance =
-				shotDistance > 23.8
-					? shotDistance.toFixed(1) + " feet"
-					: "from the corner";
+				shotDistance > 23.8 ? shotDistance.toFixed(1) + " feet" : "the corner";
 
 			this.recordPlay("fgaTp", this.o, [
 				this.team[this.o].player[p].name,

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -1345,7 +1345,7 @@ class GameSim {
 			// Great shooters shoot from deeper ranges
 			const threePointAbility =
 				this.team[this.o].player[p].compositeRating.shootingThreePointer * 100;
-			if (threePointAbility > 0.65) {
+			if (threePointAbility > 65) {
 				// 90 tp rating will have a meanDistance of 28.25, SD of 2.625
 				meanDistance += threePointAbility / 40;
 				distanceDeviation += threePointAbility / 80;

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -1360,7 +1360,7 @@ class GameSim {
 			probMake *= g.get("threePointAccuracyFactor");
 
 			// 22 FT is where the corner three line is, 94 FT is length of court
-			let shotDistance = helpers.bound(
+			const shotDistance = helpers.bound(
 				random.gauss(meanDistance, distanceDeviation),
 				22,
 				94,

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -1364,7 +1364,7 @@ class GameSim {
 
 			this.recordPlay("fgaTp", this.o, [
 				this.team[this.o].player[p].name,
-				shotDistance,
+				shotDistance.toFixed(),
 			]);
 		} else {
 			const r1 =

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -1359,16 +1359,20 @@ class GameSim {
 			}
 			probMake *= g.get("threePointAccuracyFactor");
 
-			// 24 FT is where the tp line is, 94 FT is length of court
-			const shotDistance = helpers.bound(
-				Math.round(random.gauss(meanDistance, distanceDeviation)),
-				24,
+			// 22 FT is where the corner three line is, 94 FT is length of court
+			let shotDistance = helpers.bound(
+				random.gauss(meanDistance, distanceDeviation),
+				22,
 				94,
 			);
+			const distance =
+				shotDistance > 23.8
+					? shotDistance.toFixed(1) + " feet"
+					: "from the corner";
 
 			this.recordPlay("fgaTp", this.o, [
 				this.team[this.o].player[p].name,
-				shotDistance.toFixed(),
+				distance,
 			]);
 		} else {
 			const r1 =
@@ -2095,7 +2099,7 @@ class GameSim {
 			} else if (type === "fgaMidRange") {
 				texts = ["{0} attempts a mid-range shot"];
 			} else if (type === "fgaTp") {
-				texts = [`{0} attempts a ${threePointerText} from {1} feet`];
+				texts = [`{0} attempts a ${threePointerText} from {1}`];
 			} else if (type === "fgAtRim") {
 				// Randomly pick a name to be dunked on
 				const ratios = this.ratingArray("blocking", this.d, 5);

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -2055,6 +2055,11 @@ class GameSim {
 			const threePointerText = g.get("threePointers")
 				? "three pointer"
 				: "deep shot";
+			const threePointDistance = helpers.bound(
+				Math.round(random.gauss(26.1, 1.5)),
+				24,
+				94,
+			);
 
 			let showScore = false;
 			if (type === "injury") {
@@ -2070,7 +2075,9 @@ class GameSim {
 			} else if (type === "fgaMidRange") {
 				texts = ["{0} attempts a mid-range shot"];
 			} else if (type === "fgaTp") {
-				texts = [`{0} attempts a ${threePointerText}`];
+				texts = [
+					`{0} attempts a ${threePointerText} from ${threePointDistance} feet`,
+				];
 			} else if (type === "fgAtRim") {
 				// Randomly pick a name to be dunked on
 				const ratios = this.ratingArray("blocking", this.d, 5);

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -1338,12 +1338,15 @@ class GameSim {
 			probMake = shootingThreePointerScaled * 0.3 + 0.36;
 			probAndOne = 0.01;
 
+			// Show shot distance when a player attempts a deep shot
 			let meanDistance = 26;
 			let distanceDeviation = 1.5;
+
 			// Great shooters shoot from deeper ranges
 			const threePointAbility =
 				this.team[this.o].player[p].compositeRating.shootingThreePointer * 100;
-			if (threePointAbility > 0.69) {
+			if (threePointAbility > 0.65) {
+				// 90 tp rating will have a meanDistance of 28.25, SD of 2.625
 				meanDistance += threePointAbility / 40;
 				distanceDeviation += threePointAbility / 80;
 			}
@@ -1356,6 +1359,7 @@ class GameSim {
 			}
 			probMake *= g.get("threePointAccuracyFactor");
 
+			// 24 FT is where the tp line is, 94 FT is length of court
 			const shotDistance = helpers.bound(
 				Math.round(random.gauss(meanDistance, distanceDeviation)),
 				24,


### PR DESCRIPTION
The 2019 NBA shot distance graph I posted in Discord, x = feet
![image](https://user-images.githubusercontent.com/67447432/107932452-6fd1cb00-6f32-11eb-89fb-e80f1bf9e83f.png)




Average three point shot distance in BBGM (x = feet)
![image](https://user-images.githubusercontent.com/67447432/107930440-d86b7880-6f2f-11eb-9c39-8bfe64a98215.png)

Player with 90 TP rating
![image](https://user-images.githubusercontent.com/67447432/107930614-12d51580-6f30-11eb-90cb-2713a0bc8012.png)
Woulda used matplotlib to get much better graphs with a min limit but I can't f*kin stand PY package management

![image](https://user-images.githubusercontent.com/67447432/107929731-ebca1400-6f2e-11eb-9487-48c59deed633.png)

Just about any play logger like ESPN or bball-ref shows shot distance in feet.
![image](https://user-images.githubusercontent.com/67447432/107932218-28e3d580-6f32-11eb-94c7-c081efcac37e.png)


It's a requested feature. Looks cool, adds fun context. Imagine all the content that'll get posted of someone showing their player banging a three from 35 feet to win G7 of Finals.