### PR TITLE
MOV on roster page has color

### DIFF
--- a/src/ui/views/Roster/TopStuff.tsx
+++ b/src/ui/views/Roster/TopStuff.tsx
@@ -1,6 +1,10 @@
 import PropTypes from "prop-types";
 import { useState, CSSProperties } from "react";
-import { RecordAndPlayoffs, RosterComposition } from "../../components";
+import {
+	RecordAndPlayoffs,
+	RosterComposition,
+	PlusMinus,
+} from "../../components";
 import { helpers } from "../../util";
 import InstructionsAndSortButtons from "./InstructionsAndSortButtons";
 import type { View } from "../../../common/types";
@@ -115,17 +119,13 @@ const TopStuff = ({
 			"Season not found"
 		);
 
-	let marginOfVictory: string;
+	let marginOfVictory = 0;
 	if (isSport("football") || isSport("hockey")) {
 		if (t.stats.gp !== 0) {
-			marginOfVictory = ((t.stats.pts - t.stats.oppPts) / t.stats.gp).toFixed(
-				1,
-			);
-		} else {
-			marginOfVictory = "0.0";
+			marginOfVictory = (t.stats.pts - t.stats.oppPts) / t.stats.gp;
 		}
 	} else {
-		marginOfVictory = (t.stats.pts - t.stats.oppPts).toFixed(1);
+		marginOfVictory = t.stats.pts - t.stats.oppPts;
 	}
 
 	return (
@@ -149,7 +149,7 @@ const TopStuff = ({
 							</>
 						) : null}
 						<span title="Average margin of victory">Average MOV</span>:{" "}
-						{marginOfVictory}
+						<PlusMinus>{marginOfVictory}</PlusMinus>
 					</div>
 
 					{season === currentSeason || isSport("football") ? (


### PR DESCRIPTION
I forgot to take a screenshot in my local copy before closing it.
Imagine the "9.9" is green, and if it were negative, it'd be red.

![image](https://user-images.githubusercontent.com/67447432/113249533-b32e9180-9273-11eb-9806-edd4d161c807.png)
