### PR TITLE
Unlink League/Team Stats columns

### DIFF
--- a/src/ui/views/LeagueStats.tsx
+++ b/src/ui/views/LeagueStats.tsx
@@ -155,7 +155,7 @@ const LeagueStats = ({
 			<DataTable
 				cols={cols}
 				defaultSort={[0, "desc"]}
-				name={`TeamStats${teamOpponent}`}
+				name={`LeagueStats${teamOpponent}`}
 				pagination={pagination}
 				rows={rows}
 				superCols={superCols}


### PR DESCRIPTION
If you customize columns on either page, it messes up the other. This one-line change fixes it.