### PR TITLE
Add UI setting to show team names in the league dashboard standings

### DIFF
--- a/src/common/defaultGameAttributes.ts
+++ b/src/common/defaultGameAttributes.ts
@@ -150,6 +150,7 @@ const defaultGameAttributes: GameAttributesLeagueWithHistory = {
 	randomDebutsForever: undefined,
 	realDraftRatings: undefined,
 	hideDisabledTeams: false,
+	useNamesInLeagueDashboard: false,
 	goatFormula: undefined,
 	inflationAvg: 0,
 	inflationMax: 0,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -565,6 +565,7 @@ export type GameAttributesLeague = {
 	ties: boolean;
 	tradeDeadline: number;
 	tragicDeathRate: number;
+	useNamesInLeagueDashboard: boolean;
 	userTid: number;
 	userTids: number[];
 

--- a/src/ui/util/local.ts
+++ b/src/ui/util/local.ts
@@ -73,6 +73,7 @@ const useLocal = create(
 		statusText: "Idle",
 		teamInfoCache: [],
 		units: defaultUnits,
+		useNamesInLeagueDashboard: false,
 		userTid: 0,
 		userTids: [],
 		username: undefined,
@@ -132,6 +133,7 @@ const useLocal = create(
 					godMode: false,
 					hideDisabledTeams: false,
 					homeCourtAdvantage: 1,
+					useNamesInLeagueDashboard: false,
 
 					// Controller.tsx relies on this being undefined (or at least different than the new lid) to trigger calling beforeView.league
 					lid: undefined,
@@ -188,6 +190,7 @@ const useLocal = create(
 					"spectator",
 					"startingSeason",
 					"teamInfoCache",
+					"useNamesInLeagueDashboard",
 					"userTid",
 					"userTids",
 				] as const;

--- a/src/ui/views/LeagueDashboard/Standings.tsx
+++ b/src/ui/views/LeagueDashboard/Standings.tsx
@@ -13,6 +13,7 @@ const Standings = ({
 	numPlayoffTeams,
 	playoffsByConf,
 	pointsFormula,
+	useNames,
 	usePts,
 	userTid,
 }: Pick<
@@ -46,7 +47,12 @@ const Standings = ({
 								"table-info": t.tid === userTid,
 							})}
 						>
-							<TeamColumn rank={t.rank} rankWidth={15} t={t} />
+							<TeamColumn
+								rank={t.rank}
+								rankWidth={15}
+								t={t}
+								includeName={useNames}
+							/>
 							<td className="text-right">
 								{usePts ? Math.round(t.seasonAttrs.pts) : t.gb}
 							</td>

--- a/src/ui/views/LeagueDashboard/index.tsx
+++ b/src/ui/views/LeagueDashboard/index.tsx
@@ -43,6 +43,7 @@ const LeagueDashboard = ({
 	teamLeaders,
 	teamStats,
 	tied,
+	useNames,
 	usePts,
 	userTid,
 	won,
@@ -79,6 +80,7 @@ const LeagueDashboard = ({
 									numPlayoffTeams={numPlayoffTeams}
 									playoffsByConf={playoffsByConf}
 									pointsFormula={pointsFormula}
+									useNames={useNames}
 									usePts={usePts}
 									userTid={userTid}
 								/>

--- a/src/ui/views/Settings/settings.tsx
+++ b/src/ui/views/Settings/settings.tsx
@@ -1421,6 +1421,14 @@ settings.push(
 		descriptionLong:
 			"This will hide inactive teams from dropdown menus at the top of many pages, such as the roster page.",
 	},
+	{
+		category: "UI",
+		key: "useNamesInLeagueDashboard",
+		name: "Use Names In League Dashboard",
+		type: "bool",
+		descriptionLong:
+			"This will include team names in the league dashboard standings, in addition to region. Useful for leagues where all teams are in the same region.",
+	},
 );
 
 if (isSport("basketball")) {

--- a/src/worker/core/league/gameAttributesToUI.ts
+++ b/src/worker/core/league/gameAttributesToUI.ts
@@ -24,6 +24,7 @@ const gameAttributesToUI = async (
 		"spectator",
 		"startingSeason",
 		"teamInfoCache",
+		"useNamesInLeagueDashboard",
 		"userTid",
 		"userTids",
 	] as const;

--- a/src/worker/views/leagueDashboard.ts
+++ b/src/worker/views/leagueDashboard.ts
@@ -472,6 +472,7 @@ const updateStandings = async (inputs: unknown, updateEvents: UpdateEvents) => {
 				"did",
 				"abbrev",
 				"region",
+				"name",
 				"clinchedPlayoffs",
 				"imgURL",
 				"imgURLSmall",
@@ -531,6 +532,7 @@ const updateStandings = async (inputs: unknown, updateEvents: UpdateEvents) => {
 			numPlayoffTeams,
 			playoffsByConf,
 			pointsFormula,
+			useNames: g.get("useNamesInLeagueDashboard"),
 			usePts,
 		};
 	}


### PR DESCRIPTION
As I put it in the setting's description:

> This will include team names in the league dashboard standings, in addition to region. Useful for leagues where all teams are in the same region.

Notably, I've got a FBGM league where all teams play in the same region, and without this setting, I've resorted to making each team's region its abbreviation (so, for instance, the Apollos are stored as `APO Apollos`) so I can tell them apart in the dashboard view. I also know of at least one real-life football league (Fan Controlled Football) that has a similar arrangement.