### PR TITLE
Make scoreboxes scrollable (#301)

### DIFF
--- a/public/css/light.scss
+++ b/public/css/light.scss
@@ -947,6 +947,8 @@ tr.table-warning:hover > td {
 	width: 15px;
 	height: 56px;
 	z-index: 1000;
+	position: absolute;
+	right: 0px;
 }
 
 .score-box-deadline {

--- a/public/css/sidebar.scss
+++ b/public/css/sidebar.scss
@@ -66,6 +66,17 @@
 	}
 	.league-top-bar {
 		margin-left: 161px;
+		&::-webkit-scrollbar {
+			height: 3px;
+		}
+		&::-webkit-scrollbar-track {
+			background: #dadada;
+			border-radius: 50px;
+		}
+		&::-webkit-scrollbar-thumb {
+			background: rgba(71, 71, 71, 0.637);
+			border-radius: 50px;
+		}
 	}
 	.title-bar {
 		// -17 for left margin in .title-bar

--- a/src/ui/components/LeagueTopBar.tsx
+++ b/src/ui/components/LeagueTopBar.tsx
@@ -126,7 +126,7 @@ const LeagueTopBar = memo(() => {
 
 	return (
 		<div
-			className="league-top-bar flex-shrink-0 d-flex overflow-auto flex-row-reverse pr-3 pb-1 mt-2"
+			className="league-top-bar flex-shrink-0 d-flex overflow-auto flex-row-reverse pr-3 pl-1 pb-1 mt-2"
 			style={show ? undefined : hiddenStyle}
 			ref={leagueTopBarRef}
 		>

--- a/src/ui/components/LeagueTopBar.tsx
+++ b/src/ui/components/LeagueTopBar.tsx
@@ -42,6 +42,17 @@ const LeagueTopBar = memo(() => {
 		}
 		return true;
 	});
+
+	useEffect(() => {
+		if (show) {
+			const leagueTopBar = document.querySelector(".league-top-bar");
+			leagueTopBar?.scrollTo({
+				left: leagueTopBar.scrollWidth,
+				behavior: "smooth",
+			});
+		}
+	});
+
 	const [numberOfScoreBoxes, setNumberOfScoreBoxes] = useState(10);
 	const prevGames = useRef<typeof games>([]);
 
@@ -86,18 +97,13 @@ const LeagueTopBar = memo(() => {
 				break;
 			}
 		}
-
-		const start = games2.length - numberOfScoreBoxes;
-		if (start > 0) {
-			games2 = games2.slice(start);
-		}
 	}
 
 	const transition = { duration: 0.2, type: "tween" };
 
 	return (
 		<div
-			className="league-top-bar flex-shrink-0 d-flex justify-content-end overflow-hidden mt-2"
+			className="league-top-bar flex-shrink-0 d-flex overflow-auto mt-2"
 			style={show ? undefined : hiddenStyle}
 		>
 			{show ? (

--- a/src/ui/components/LeagueTopBar.tsx
+++ b/src/ui/components/LeagueTopBar.tsx
@@ -83,7 +83,7 @@ const LeagueTopBar = memo(() => {
 				passive: false,
 			});
 		};
-	});
+	}, [handleWheel, show]);
 
 	const handleWheel = useCallback(e => {
 		e.preventDefault();

--- a/src/ui/components/LeagueTopBar.tsx
+++ b/src/ui/components/LeagueTopBar.tsx
@@ -65,6 +65,19 @@ const LeagueTopBar = memo(() => {
 		};
 	}, [updateNumberOfScoreBoxes]);
 
+	let games2: typeof games = [];
+
+	const handleWheel = useCallback(e => {
+		e.preventDefault();
+		const leagueTopBarPosition = leagueTopBarRef.current.scrollLeft;
+
+		leagueTopBarRef.current.scrollTo({
+			top: 0,
+			left: leagueTopBarPosition - e.deltaY + e.deltaX,
+			behaviour: "smooth",
+		});
+	}, []);
+
 	useEffect(() => {
 		const leagueTopBar = leagueTopBarRef.current;
 		if (
@@ -83,18 +96,7 @@ const LeagueTopBar = memo(() => {
 				passive: false,
 			});
 		};
-	}, [handleWheel, show]);
-
-	const handleWheel = useCallback(e => {
-		e.preventDefault();
-		const leagueTopBarPosition = leagueTopBarRef.current.scrollLeft;
-
-		leagueTopBarRef.current.scrollTo({
-			top: 0,
-			left: leagueTopBarPosition - e.deltaY + e.deltaX,
-			behaviour: "smooth",
-		});
-	}, []);
+	}, [handleWheel, show, games2]);
 
 	// If you take control of an expansion team after the season, the ASG is the only game, and it looks weird to show just it
 	const onlyAllStarGame =
@@ -111,7 +113,7 @@ const LeagueTopBar = memo(() => {
 		prevGames.current = games;
 	}
 
-	let games2: typeof games = [];
+	// let games2: typeof games = [];
 	if (show) {
 		// Show only the first upcoming game
 		for (const game of prevGames.current) {


### PR DESCRIPTION
- Edited toggle bar to overflow-auto (from overflow-hidden) to enable scrolling
- Edited scss to ensure toggle button always remains on the right side of the page
- Deleted manipulation of games2 to allow all previous games to be accessible
- Added useEffect to always have scrollboxes scroll to the most current game (probabably more efficient way to scroll, as the useEffect triggers after every render)