### PR TITLE
Frivolity for Oldest Champion Team

### DIFF
--- a/src/ui/views/Frivolities.tsx
+++ b/src/ui/views/Frivolities.tsx
@@ -102,6 +102,11 @@ export const frivolities = {
 			name: "Worst Championship Teams",
 			description: "The worst seasons from teams that won the title.",
 		},
+		{
+			urlParts: ["teams", "old_champ"],
+			name: "Oldest Championship Teams",
+			description: "The oldest teams that won the title.",
+		},
 	],
 	Trades: [
 		{

--- a/src/worker/views/frivolitiesTeamSeasons.ts
+++ b/src/worker/views/frivolitiesTeamSeasons.ts
@@ -348,12 +348,12 @@ const updateFrivolitiesTeamSeasons = async (
 					return;
 				}
 				return {
-					value: ts.avgAge ? Math.round(ts.avgAge * 100) / 100 : 0,
+					value: ts.avgAge ? ts.avgAge : 0,
 					roundsWonText,
 				};
 			};
 			sortParams = [
-				["most.value", "mov"],
+				["most.value", "winp"],
 				["desc", "desc"],
 			];
 		} else {

--- a/src/worker/views/frivolitiesTeamSeasons.ts
+++ b/src/worker/views/frivolitiesTeamSeasons.ts
@@ -2,7 +2,7 @@ import { idb, iterate } from "../db";
 import { g, helpers } from "../util";
 import type { UpdateEvents, ViewInput, TeamSeason } from "../../common/types";
 import { isSport, PHASE } from "../../common";
-import orderBy from "lodash-es/orderBy";
+import { orderBy } from "lodash-es";
 import { team } from "../core";
 
 type Most = {
@@ -79,6 +79,7 @@ export const getMostXTeamSeasons = async ({
 				pts: 0,
 				oppPts: 0,
 				most: after ? await after(ts.most) : ts.most,
+				avgAge: ts.avgAge ? ts.avgAge.toFixed(1) : "0",
 			};
 		}),
 	);
@@ -314,6 +315,46 @@ const updateFrivolitiesTeamSeasons = async (
 			sortParams = [
 				["most.value", "mov"],
 				["desc", "asc"],
+			];
+		} else if (type === "old_champ") {
+			title = "Oldest Championship Teams";
+			description = "These are oldest teams that won the title.";
+			extraCols.push(
+				{
+					key: "avgAge",
+					colName: "AvgAge",
+				},
+				{
+					key: "seed",
+					colName: "Seed",
+				},
+				{
+					key: ["most", "roundsWonText"],
+					keySort: "playoffRoundsWon",
+					colName: "Rounds Won",
+				},
+			);
+
+			filter = ts =>
+				!!ts.avgAge &&
+				ts.playoffRoundsWon >= 0 &&
+				(season > ts.season || phase > PHASE.PLAYOFFS);
+			getValue = ts => {
+				const roundsWonText = getRoundsWonText(ts);
+
+				// Keep in sync with helpers.roundsWonText
+				const validTexts = ["League champs"];
+				if (!validTexts.includes(roundsWonText)) {
+					return;
+				}
+				return {
+					value: ts.avgAge ? Math.round(ts.avgAge * 100) / 100 : 0,
+					roundsWonText,
+				};
+			};
+			sortParams = [
+				["most.value", "mov"],
+				["desc", "desc"],
 			];
 		} else {
 			throw new Error(`Unknown type "${type}"`);


### PR DESCRIPTION
- Not sure if you wanted tests, since there aren't any currently that I can see.
- Right now the default value if  `avgAge` is undefined is 0, which I don't think should happen since it should filter out any seasons with no `avgAge`.
- Right now it's rounded to one decimal place, since that's what is on the roster screen, so I figured that would be best. 
- `avgAge` is the main sortParam, but I included `winp` in the unlikely case that there is the exact same `avgAge` value before rounding.
- I noticed on the "worst championship teams", the title says "worst champion team". Not sure exactly why you did that, if you wanted to keep that I can change it to "oldest champion team" for the new frivolity.