### PR TITLE
Use "after trade team ovr" when evaluating draft pick value in trades

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1663,6 +1663,7 @@ export type TradeTeam = {
 	tid: number;
 	warning?: string | null;
 	warningAmount?: number;
+	ovrAfter?: number;
 };
 
 export type TradeTeams = [TradeTeam, TradeTeam];

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -431,22 +431,28 @@ const refreshCache = async () => {
 		tid: number;
 		ovr: number;
 	}[] = [];
+	const currTrade = await idb.cache.trade.get(0);
 	for (const [tidString, players] of Object.entries(playersByTid)) {
+		let ovr;
 		const tid = parseInt(tidString);
-		const ovr = team.ovr(
-			players.map(p => ({
-				pid: p.pid,
-				value: p.value,
-				ratings: {
-					ovr: p.ratings.at(-1)!.ovr,
-					ovrs: p.ratings.at(-1)!.ovrs,
-					pos: p.ratings.at(-1)!.pos,
+		if (tid == currTrade?.teams[1].tid && currTrade.teams[1].ovrAfter) {
+			ovr = currTrade.teams[1].ovrAfter;
+		} else {
+			ovr = team.ovr(
+				players.map(p => ({
+					pid: p.pid,
+					value: p.value,
+					ratings: {
+						ovr: p.ratings.at(-1)!.ovr,
+						ovrs: p.ratings.at(-1)!.ovrs,
+						pos: p.ratings.at(-1)!.pos,
+					},
+				})),
+				{
+					fast: true,
 				},
-			})),
-			{
-				fast: true,
-			},
-		);
+			);
+		}
 
 		teamOvrs.push({ tid, ovr });
 	}

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -7,6 +7,9 @@ import type {
 	PlayerContract,
 	PlayerInjury,
 	DraftPick,
+	MinimalPlayerRatings,
+	Player,
+	Phase,
 } from "../../../common/types";
 import { groupBy } from "../../../common/groupBy";
 import { getNumPicksPerRound } from "../trade/getPickValues";
@@ -18,6 +21,7 @@ type Asset =
 			contractValue: number;
 			injury: PlayerInjury;
 			age: number;
+			justDrafted: boolean;
 	  }
 	| {
 			type: "pick";
@@ -97,6 +101,8 @@ const getPlayers = async ({
 	tid: number;
 	tradingPartnerTid?: number;
 }) => {
+	const season = g.get("season");
+	const phase = g.get("phase");
 	const difficultyFudgeFactor = helpers.bound(
 		1 + 0.1 * g.get("difficulty"),
 		0,
@@ -122,6 +128,7 @@ const getPlayers = async ({
 				contractValue: getContractValue(p.contract, value),
 				injury: p.injury,
 				age: g.get("season") - p.born.year,
+				justDrafted: justDrafted(p, phase, season),
 			});
 		} else {
 			// Only apply fudge factor to positive assets
@@ -136,6 +143,7 @@ const getPlayers = async ({
 				contractValue: getContractValue(p.contract, value),
 				injury: p.injury,
 				age: g.get("season") - p.born.year,
+				justDrafted: justDrafted(p, phase, season),
 			});
 		}
 	}
@@ -152,9 +160,24 @@ const getPlayers = async ({
 				contractValue: getContractValue(p.contract, value),
 				injury: p.injury,
 				age: g.get("season") - p.born.year,
+				justDrafted: justDrafted(p, phase, season),
 			});
 		}
 	}
+};
+
+const justDrafted = (
+	p: Player<MinimalPlayerRatings>,
+	phase: Phase,
+	season: number,
+) => {
+	return (
+		!!p.contract.rookie &&
+		((p.draft.year === season && phase >= PHASE.DRAFT) ||
+			(p.draft.year === season - 1 &&
+				phase < PHASE.REGULAR_SEASON &&
+				phase >= 0))
+	);
 };
 
 const getPickNumber = (
@@ -416,6 +439,12 @@ const sumValues = (
 
 		const contractsFactor = strategy === "rebuilding" ? 2 : 0.5;
 		playerValue += contractsFactor * p.contractValue;
+
+		// if a player was just drafted and can be released, they shouldn't have negative value
+		if (p.type == "player" && p.justDrafted) {
+			playerValue = Math.max(0, playerValue);
+		}
+
 		// console.log(playerValue, p);
 
 		return memo + (playerValue > 1 ? playerValue ** EXPONENT : playerValue);

--- a/src/worker/core/trade/summary.ts
+++ b/src/worker/core/trade/summary.ts
@@ -98,7 +98,7 @@ const summary = async (teams: TradeTeams): Promise<TradeSummary> => {
 		if (i == 1) {
 			const tradeToUpdate = (await idb.cache.trade.get(0))!;
 			tradeToUpdate.teams[1].ovrAfter = s.teams[1].ovrAfter;
-			await idb.cache.trade.put({ ...tradeToUpdate });
+			await idb.cache.trade.put(tradeToUpdate);
 		}
 	}
 

--- a/src/worker/core/trade/summary.ts
+++ b/src/worker/core/trade/summary.ts
@@ -95,6 +95,11 @@ const summary = async (teams: TradeTeams): Promise<TradeSummary> => {
 	}
 	for (const i of [0, 1] as const) {
 		s.teams[i].ovrAfter = await getTeamOvr(playersAfter[i]);
+		if (i == 1) {
+			const tradeToUpdate = (await idb.cache.trade.get(0))!;
+			tradeToUpdate.teams[1].ovrAfter = s.teams[1].ovrAfter;
+			await idb.cache.trade.put({ ...tradeToUpdate });
+		}
 	}
 
 	const overCap = [false, false];


### PR DESCRIPTION
This is a follow up PR to a minor "issue" I found [here](https://www.reddit.com/r/BasketballGM/comments/zfebsb/ai_trade_logic_feels_broken/). 

The TL;DR is it would make sense to me that if a CPU team is evaluating their draft pick's value and is using team ovr as part of the calculation, it should based on the after trade team ovr, not the before. 

I tested this locally on insane mode,  and it seems to be a little improved in my view.
On master
https://imgur.com/8XJoVsJ
On the branch
https://imgur.com/7maEFC2

I basically offered a valuable prospect and saw what a CPU might offer back in default. In the master, the CPU offers 2 1sts including the current year despite gutting their team ovr to like -66 or something, which is a lock for a top 5 pick despite the CPU valuing it as a late 1st. On the branch, the CPU only offers 2nds in this case instead when offering all the players, which seems subtle but I think is a big difference: picks around ~30 rather than picks in the top 5.

I'm sure you have preferences for how you access the cache or the type of data you store in places. This is my first time really looking the codebase so I just added a field to an existing data type, but feel free to suggest doing it totally differently if it looks too hacky 