### PR TITLE
Dynamically reevaluate first round picks during trades

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -1366,8 +1366,33 @@ const sum = (values: (number | undefined)[]) => {
 	return total;
 };
 
+const binarySearch = (a: number[], searchNum: number): number => {
+	return binarySearch0(a, 0, a.length, searchNum);
+};
+
+// Like public version, but without range checks.
+const binarySearch0 = (
+	a: number[],
+	fromIndex: number,
+	toIndex: number,
+	searchNum: number,
+) => {
+	let low = fromIndex;
+	let high = toIndex - 1;
+
+	while (low <= high) {
+		const mid = (low + high) >>> 1;
+		const midVal = a[mid];
+
+		if (midVal < searchNum) low = mid + 1;
+		else if (midVal > searchNum) high = mid - 1;
+		else return mid; // key found
+	}
+	return low; // key not found.
+};
 export default {
 	addPopRank,
+	binarySearch,
 	getPopRanks,
 	gameScore,
 	getCountry,

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -1366,16 +1366,20 @@ const sum = (values: (number | undefined)[]) => {
 	return total;
 };
 
-const binarySearch = (a: number[], searchNum: number): number => {
-	return binarySearch0(a, 0, a.length, searchNum);
+const binarySearch = (
+	a: number[],
+	searchNum: number,
+	ascending: boolean = true,
+): number => {
+	return binarySearch0(a, 0, a.length, searchNum, ascending);
 };
 
-// Like public version, but without range checks.
 const binarySearch0 = (
 	a: number[],
 	fromIndex: number,
 	toIndex: number,
 	searchNum: number,
+	ascending: boolean,
 ) => {
 	let low = fromIndex;
 	let high = toIndex - 1;
@@ -1384,8 +1388,9 @@ const binarySearch0 = (
 		const mid = (low + high) >>> 1;
 		const midVal = a[mid];
 
-		if (midVal < searchNum) low = mid + 1;
-		else if (midVal > searchNum) high = mid - 1;
+		if (ascending ? midVal < searchNum : midVal > searchNum) low = mid + 1;
+		else if (ascending ? midVal > searchNum : midVal < searchNum)
+			high = mid - 1;
 		else return mid; // key found
 	}
 	return low; // key not found.

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -1366,6 +1366,8 @@ const sum = (values: (number | undefined)[]) => {
 	return total;
 };
 
+// pulled from this stack overflow link and modified:
+// https://stackoverflow.com/questions/13306537/how-to-find-the-insertion-point-in-an-array-using-binary-search
 const binarySearch = (
 	a: number[],
 	searchNum: number,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1663,6 +1663,7 @@ export type TradeTeam = {
 	tid: number;
 	warning?: string | null;
 	warningAmount?: number;
+	ovrAfter?: number;
 };
 
 export type TradeTeams = [TradeTeam, TradeTeam];

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1663,7 +1663,6 @@ export type TradeTeam = {
 	tid: number;
 	warning?: string | null;
 	warningAmount?: number;
-	ovrAfter?: number;
 };
 
 export type TradeTeams = [TradeTeam, TradeTeam];

--- a/src/worker/core/team/ovr.basketball.ts
+++ b/src/worker/core/team/ovr.basketball.ts
@@ -1,9 +1,17 @@
+import { player } from "..";
+
 const ovr = (
-	players: {
-		ratings: {
-			ovr: number;
-			pos: string;
-		};
+	playersRaw: {
+		ratings:
+			| {
+					ovr: number;
+					pos: string;
+			  }
+			| {
+					fuzz: number;
+					ovr: number;
+					pos: string;
+			  }[];
 	}[],
 	{
 		playoffs = false,
@@ -13,6 +21,31 @@ const ovr = (
 		rating?: string;
 	},
 ) => {
+	let players: {
+		ratings: {
+			ovr: number;
+			pos: string;
+		};
+	}[];
+	if (playersRaw.length > 0 && Array.isArray(playersRaw[0].ratings)) {
+		players = playersRaw.map(p => {
+			const ratings = (p.ratings as any).at(-1)! as {
+				fuzz: number;
+				ovr: number;
+				pos: string;
+			};
+
+			return {
+				ratings: {
+					ovr: player.fuzzRating(ratings!.ovr, ratings!.fuzz),
+					pos: ratings!.pos,
+				},
+			};
+		});
+	} else {
+		players = playersRaw as any;
+	}
+
 	const ratings = players
 		.slice()
 		// Sort first, so non-ovr ratings are based on the top ovr players

--- a/src/worker/core/team/ovr.ts
+++ b/src/worker/core/team/ovr.ts
@@ -8,13 +8,20 @@ import ovrHockey from "./ovr.hockey";
 // wholeRoster=true is used for computing team value of the whole roster, like for determining who to draft or sign
 const ovr = (
 	players: {
-		pid: number | undefined;
+		pid?: number;
 		value: number;
-		ratings: {
-			ovr: number;
-			ovrs: Record<string, number> | undefined;
-			pos: string;
-		};
+		ratings:
+			| {
+					ovr: number;
+					ovrs?: Record<string, number>;
+					pos: string;
+			  }
+			| {
+					fuzz: number;
+					ovr: number;
+					ovrs?: Record<string, number>;
+					pos: string;
+			  }[];
 	}[],
 	options: {
 		fast?: boolean;

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -506,6 +506,7 @@ const refreshCache = async () => {
 	let gp = 0;
 
 	const wps = teamOvrs.map((teamOvrObj, rank) => {
+		// 25% to 75% based on rank
 		const teamOvrWinp =
 			0.25 + (0.5 * (teams.length - 1 - rank)) / (teams.length - 1);
 		const teamSeasons = allTeamSeasons.filter(
@@ -632,10 +633,11 @@ const getModifiedPickRank = async (
 		});
 	}
 	const newTeamOvr = await getTeamOvr(players);
-	// potential speed up: use binary search instead of linear search on sorted arrays
-	const newTeamOvrRank = Math.max(
-		helpers.binarySearch(cache.sortedTeamOvrs, newTeamOvr, false),
-		1,
+	// we use binary search instead of indexOf to take advantage of the sorted array
+	const newTeamOvrRank = helpers.binarySearch(
+		cache.sortedTeamOvrs,
+		newTeamOvr,
+		false,
 	);
 	const newTeamOvrWinp =
 		0.25 +
@@ -646,10 +648,7 @@ const getModifiedPickRank = async (
 			? newTeamOvrWinp
 			: seasonFraction * (record[0] / cache.gp) +
 			  (1 - seasonFraction) * newTeamOvrWinp;
-	const newEstPick = Math.max(
-		helpers.binarySearch(cache.sortedWps, newWp) + 1,
-		1,
-	);
+	const newEstPick = helpers.binarySearch(cache.sortedWps, newWp) + 1;
 	return newEstPick;
 };
 

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -633,8 +633,10 @@ const getModifiedPickRank = async (
 	}
 	const newTeamOvr = await getTeamOvr(players);
 	// potential speed up: use binary search instead of linear search on sorted arrays
-	const newTeamOvrRank =
-		helpers.binarySearch(cache.sortedTeamOvrs, newTeamOvr) + 1;
+	const newTeamOvrRank = Math.max(
+		helpers.binarySearch(cache.sortedTeamOvrs, newTeamOvr, false),
+		1,
+	);
 	const newTeamOvrWinp =
 		0.25 +
 		(0.5 * (cache.sortedTeamOvrs.length - 1 - newTeamOvrRank)) /
@@ -644,7 +646,10 @@ const getModifiedPickRank = async (
 			? newTeamOvrWinp
 			: seasonFraction * (record[0] / cache.gp) +
 			  (1 - seasonFraction) * newTeamOvrWinp;
-	const newEstPick = helpers.binarySearch(cache.sortedWps, newWp) + 1;
+	const newEstPick = Math.max(
+		helpers.binarySearch(cache.sortedWps, newWp) + 1,
+		1,
+	);
 	return newEstPick;
 };
 

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -175,7 +175,7 @@ const getPickNumber = async (
 	} else {
 		let temp = undefined;
 		if (tradingPartnerTid === undefined) {
-			// This first if case will only hit when valueChange is called to determine if a team should re-sign
+			// This first if case will only hit when valueChange is called to determine if a team should re-sign a player
 			// Think dynamic pick re-evaluation could lead to some unexpected behavior here (teams end up letting a
 			// lot of players walk to tank their pick/increase overall value) so the old behavior is retained for this case
 			temp = await getModifiedPickRank(tid, [], []);

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -629,11 +629,10 @@ const getModifiedPickRank = async (
 	players.push(...t2Players);
 	const newTeamOvr = await getTeamOvr(players);
 	// potential speed up: use binary search instead of linear search on sorted arrays
-	let newTeamOvrRank = await cache.sortedTeamOvrs.findIndex(
-		t => newTeamOvr > t.ovr,
-	);
-	newTeamOvrRank =
-		newTeamOvrRank == -1 ? cache.sortedTeamOvrs.length : newTeamOvrRank + 1;
+	const newTeamOvrRank =
+		cache.sortedTeamOvrs[cache.sortedTeamOvrs.length - 1].ovr > newTeamOvr
+			? cache.sortedTeamOvrs.length
+			: (await cache.sortedTeamOvrs.findIndex(t => newTeamOvr > t.ovr)) + 1;
 	const newTeamOvrWinp =
 		0.25 +
 		(0.5 * (cache.sortedTeamOvrs.length - 1 - newTeamOvrRank)) /
@@ -643,8 +642,10 @@ const getModifiedPickRank = async (
 			? newTeamOvrWinp
 			: seasonFraction * (record[0] / cache.gp) +
 			  (1 - seasonFraction) * newTeamOvrWinp;
-	let newEstPick = await cache.sortedWps.findIndex(wp => newWp < wp);
-	newEstPick = newEstPick == -1 ? cache.sortedTeamOvrs.length : newEstPick + 1;
+	const newEstPick =
+		newWp > cache.sortedWps[cache.sortedWps.length - 1]
+			? cache.sortedWps.length
+			: (await cache.sortedWps.findIndex(wp => newWp < wp)) + 1;
 	return newEstPick;
 };
 

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -10,7 +10,6 @@ import type {
 } from "../../../common/types";
 import { groupBy } from "../../../common/groupBy";
 import { getNumPicksPerRound } from "../trade/getPickValues";
-import { getTeamOvr } from "../trade/summary";
 
 type Asset =
 	| {
@@ -632,7 +631,7 @@ const getModifiedPickRank = async (
 			}
 		});
 	}
-	const newTeamOvr = await getTeamOvr(players);
+	const newTeamOvr = team.ovr(players);
 	// we use binary search instead of indexOf to take advantage of the sorted array
 	const newTeamOvrRank = helpers.binarySearch(
 		cache.sortedTeamOvrs,

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -431,22 +431,28 @@ const refreshCache = async () => {
 		tid: number;
 		ovr: number;
 	}[] = [];
+	const currTrade = await idb.cache.trade.get(0);
 	for (const [tidString, players] of Object.entries(playersByTid)) {
+		let ovr;
 		const tid = parseInt(tidString);
-		const ovr = team.ovr(
-			players.map(p => ({
-				pid: p.pid,
-				value: p.value,
-				ratings: {
-					ovr: p.ratings.at(-1)!.ovr,
-					ovrs: p.ratings.at(-1)!.ovrs,
-					pos: p.ratings.at(-1)!.pos,
+		if (tid == currTrade?.teams[1].tid && currTrade.teams[1].ovrAfter) {
+			ovr = currTrade.teams[1].ovrAfter;
+		} else {
+			ovr = team.ovr(
+				players.map(p => ({
+					pid: p.pid,
+					value: p.value,
+					ratings: {
+						ovr: p.ratings.at(-1)!.ovr,
+						ovrs: p.ratings.at(-1)!.ovrs,
+						pos: p.ratings.at(-1)!.pos,
+					},
+				})),
+				{
+					fast: true,
 				},
-			})),
-			{
-				fast: true,
-			},
-		);
+			);
+		}
 
 		teamOvrs.push({ tid, ovr });
 	}

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -322,6 +322,7 @@ const getPicks = async ({
 			if (!dp) {
 				continue;
 			}
+
 			const pickInfo = getPickInfo(
 				dp,
 				estValues,
@@ -434,6 +435,7 @@ const sumValues = (
 
 		const contractsFactor = strategy === "rebuilding" ? 2 : 0.5;
 		playerValue += contractsFactor * p.contractValue;
+		// console.log(playerValue, p);
 
 		return memo + (playerValue > 1 ? playerValue ** EXPONENT : playerValue);
 	}, 0);
@@ -550,6 +552,7 @@ const valueChange = async (
 	if (dpidsRemove.length > 2) {
 		return -1;
 	}
+
 	await player.updateOvrMeanStd();
 
 	// Get value and skills for each player on team or involved in the proposed transaction

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -463,8 +463,6 @@ const sumValues = (
 			playerValue = Math.max(0, playerValue);
 		}
 
-		// console.log(playerValue, p);
-
 		return memo + (playerValue > 1 ? playerValue ** EXPONENT : playerValue);
 	}, 0);
 };
@@ -580,7 +578,6 @@ const valueChange = async (
 	if (dpidsRemove.length > 2) {
 		return -1;
 	}
-
 	await player.updateOvrMeanStd();
 
 	// Get value and skills for each player on team or involved in the proposed transaction
@@ -656,22 +653,27 @@ const getModifiedPickRank = async (
 	).filter(p => pidsAdd.includes(p.pid));
 	players.push(...t2Players);
 	const newTeamOvr = await getTeamOvr(players);
+	console.log("New Team Ovr: " + newTeamOvr);
 	// potential speed up: use binary search instead of linear search on sorted arrays
 	let newTeamOvrRank = await cache.sortedTeamOvrs.findIndex(
-		t => newTeamOvr < t.ovr,
+		t => newTeamOvr > t.ovr,
 	);
 	newTeamOvrRank =
-		newTeamOvrRank == -1 ? cache.sortedTeamOvrs.length : newTeamOvrRank;
+		newTeamOvrRank == -1 ? cache.sortedTeamOvrs.length : newTeamOvrRank + 1;
+	console.log("New Team Ovr Rank:" + newTeamOvrRank);
 	const newTeamOvrWinp =
 		0.25 +
 		(0.5 * (cache.sortedTeamOvrs.length - 1 - newTeamOvrRank)) /
 			(cache.sortedTeamOvrs.length - 1);
+	console.log("New TeamOvrWinP:" + newTeamOvrWinp);
 	const newWp =
-		seasonFraction * (record[0] / cache.gp) +
-		(1 - seasonFraction) * newTeamOvrWinp;
+		cache.gp === 0
+			? newTeamOvrWinp
+			: seasonFraction * (record[0] / cache.gp) +
+			  (1 - seasonFraction) * newTeamOvrWinp;
 	let newEstPick = await cache.sortedWps.findIndex(wp => newWp < wp);
 	newEstPick = newEstPick == -1 ? cache.sortedTeamOvrs.length : newEstPick + 1;
-	console.log(newEstPick);
+	console.log("New Pick: " + newEstPick);
 	return newEstPick;
 };
 

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -7,6 +7,9 @@ import type {
 	PlayerContract,
 	PlayerInjury,
 	DraftPick,
+	MinimalPlayerRatings,
+	Player,
+	Phase,
 } from "../../../common/types";
 import { groupBy } from "../../../common/groupBy";
 import { getNumPicksPerRound } from "../trade/getPickValues";
@@ -18,6 +21,7 @@ type Asset =
 			contractValue: number;
 			injury: PlayerInjury;
 			age: number;
+			justDrafted: boolean;
 	  }
 	| {
 			type: "pick";
@@ -97,6 +101,8 @@ const getPlayers = async ({
 	tid: number;
 	tradingPartnerTid?: number;
 }) => {
+	const season = g.get("season");
+	const phase = g.get("phase");
 	const difficultyFudgeFactor = helpers.bound(
 		1 + 0.1 * g.get("difficulty"),
 		0,
@@ -122,6 +128,7 @@ const getPlayers = async ({
 				contractValue: getContractValue(p.contract, value),
 				injury: p.injury,
 				age: g.get("season") - p.born.year,
+				justDrafted: justDrafted(p, phase, season),
 			});
 		} else {
 			// Only apply fudge factor to positive assets
@@ -136,6 +143,7 @@ const getPlayers = async ({
 				contractValue: getContractValue(p.contract, value),
 				injury: p.injury,
 				age: g.get("season") - p.born.year,
+				justDrafted: justDrafted(p, phase, season),
 			});
 		}
 	}
@@ -152,9 +160,24 @@ const getPlayers = async ({
 				contractValue: getContractValue(p.contract, value),
 				injury: p.injury,
 				age: g.get("season") - p.born.year,
+				justDrafted: justDrafted(p, phase, season),
 			});
 		}
 	}
+};
+
+const justDrafted = (
+	p: Player<MinimalPlayerRatings>,
+	phase: Phase,
+	season: number,
+) => {
+	return (
+		!!p.contract.rookie &&
+		((p.draft.year === season && phase >= PHASE.DRAFT) ||
+			(p.draft.year === season - 1 &&
+				phase < PHASE.REGULAR_SEASON &&
+				phase >= 0))
+	);
 };
 
 const getPickNumber = (
@@ -416,6 +439,12 @@ const sumValues = (
 
 		const contractsFactor = strategy === "rebuilding" ? 2 : 0.5;
 		playerValue += contractsFactor * p.contractValue;
+
+		// if a player was just drafted and can be released, they shouldn't have negative value
+		if (p.type == "player" && p.justDrafted) {
+			playerValue = Math.max(0, playerValue);
+		}
+
 		// console.log(playerValue, p);
 
 		return memo + (playerValue > 1 ? playerValue ** EXPONENT : playerValue);

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -174,16 +174,21 @@ const getPickNumber = async (
 		estPick = dp.pick;
 	} else {
 		let temp = undefined;
-		// This first if case will only hit when valueChange is called when determining if a player should re-sign
-		// Think the dynamic reevaluation could lead to some unexpected behavior here (maybe teams start letting a
-		// lot of players walk to tank their pick/increase overall value) so I'm retaining the old behavior for this case
 		if (tradingPartnerTid === undefined) {
+			// This first if case will only hit when valueChange is called to determine if a team should re-sign
+			// Think dynamic pick re-evaluation could lead to some unexpected behavior here (teams end up letting a
+			// lot of players walk to tank their pick/increase overall value) so the old behavior is retained for this case
 			temp = await getModifiedPickRank(tid, [], []);
 		} else if (dp.originalTid === tid) {
+			// If this draft pick belongs to the team evaluating the trade, re-evaluate it taking into account the new players
+			// on the team
 			temp = await getModifiedPickRank(tid, pidsAdd, pidsRemove);
-		} else if (tradingPartnerTid && dp.originalTid === tradingPartnerTid) {
+		} else if (dp.originalTid === tradingPartnerTid) {
+			// If this draft pick belongs to the team proposing the trade, the CPU should calculate that
+			// the pick its receiving could change in value given the players changing hands
 			temp = await getModifiedPickRank(tradingPartnerTid, pidsRemove, pidsAdd);
 		} else {
+			// This pick is unrelated to the team involved in the trade, so don't take player exchanges into account
 			temp = await getModifiedPickRank(dp.originalTid, [], []);
 		}
 		estPick = temp !== undefined ? temp : numPicksPerRound / 2;

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -7,9 +7,6 @@ import type {
 	PlayerContract,
 	PlayerInjury,
 	DraftPick,
-	MinimalPlayerRatings,
-	Player,
-	Phase,
 } from "../../../common/types";
 import { groupBy } from "../../../common/groupBy";
 import { getNumPicksPerRound } from "../trade/getPickValues";
@@ -376,7 +373,7 @@ const sumValues = (
 	const phase = g.get("phase");
 
 	return players.reduce((memo, p) => {
-		let playerValue = p.value;
+		let playerValue: number = p.value;
 
 		const treatAsFutureDraftPick =
 			p.type === "pick" && (season !== p.draftYear || phase <= PHASE.PLAYOFFS);
@@ -628,19 +625,16 @@ const getModifiedPickRank = async (
 	).filter(p => pidsAdd.includes(p.pid));
 	players.push(...t2Players);
 	const newTeamOvr = await getTeamOvr(players);
-	console.log("New Team Ovr: " + newTeamOvr);
 	// potential speed up: use binary search instead of linear search on sorted arrays
 	let newTeamOvrRank = await cache.sortedTeamOvrs.findIndex(
 		t => newTeamOvr > t.ovr,
 	);
 	newTeamOvrRank =
 		newTeamOvrRank == -1 ? cache.sortedTeamOvrs.length : newTeamOvrRank + 1;
-	console.log("New Team Ovr Rank:" + newTeamOvrRank);
 	const newTeamOvrWinp =
 		0.25 +
 		(0.5 * (cache.sortedTeamOvrs.length - 1 - newTeamOvrRank)) /
 			(cache.sortedTeamOvrs.length - 1);
-	console.log("New TeamOvrWinP:" + newTeamOvrWinp);
 	const newWp =
 		cache.gp === 0
 			? newTeamOvrWinp
@@ -648,7 +642,6 @@ const getModifiedPickRank = async (
 			  (1 - seasonFraction) * newTeamOvrWinp;
 	let newEstPick = await cache.sortedWps.findIndex(wp => newWp < wp);
 	newEstPick = newEstPick == -1 ? cache.sortedTeamOvrs.length : newEstPick + 1;
-	console.log("New Pick: " + newEstPick);
 	return newEstPick;
 };
 

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -180,7 +180,7 @@ const getPickNumber = async (
 		// This first if case will only hit when valueChange is called when determining if a player should re-sign
 		// Think the dynamic reevaluation could lead to some unexpected behavior here (maybe teams start letting a
 		// lot of players walk to tank their pick/increase overall value) so I'm retaining the old behavior for this case
-		if (!tradingPartnerTid) {
+		if (tradingPartnerTid === undefined) {
 			temp = await getModifiedPickRank(tid, [], [], false);
 		} else if (dp.originalTid === tid) {
 			temp = await getModifiedPickRank(tid, pidsAdd, pidsRemove, true);

--- a/src/worker/core/trade/betweenAiTeams.ts
+++ b/src/worker/core/trade/betweenAiTeams.ts
@@ -115,6 +115,7 @@ const attempt = async (valueChangeKey: number) => {
 		teams[1].dpids,
 		teams[0].dpids,
 		valueChangeKey,
+		teams[1].tid,
 	);
 	if (Math.abs(dv2) > 15) {
 		return false;

--- a/src/worker/core/trade/betweenAiTeams.ts
+++ b/src/worker/core/trade/betweenAiTeams.ts
@@ -136,6 +136,7 @@ const betweenAiTeams = async () => {
 	if ((g as any).aiTrades === false && g.get("aiTradesFactor") === 1) {
 		return false;
 	}
+	// console.time('foo');
 
 	// If aiTradesFactor is not an integer, use the fractional part as a probability. Like for 3.5, 50% of the times it will be 3, and 50% will be 4.
 	// Also scale so there are fewer trade attempts if there are fewer teams.
@@ -151,6 +152,7 @@ const betweenAiTeams = async () => {
 	if (remainder > 0 && Math.random() < remainder) {
 		numAttempts += 1;
 	}
+	// numAttempts *= 100;
 
 	if (numAttempts > 0) {
 		let valueChangeKey = Math.random();
@@ -162,6 +164,7 @@ const betweenAiTeams = async () => {
 			}
 		}
 	}
+	// console.timeEnd('foo');
 };
 
 export default betweenAiTeams;

--- a/src/worker/core/trade/summary.ts
+++ b/src/worker/core/trade/summary.ts
@@ -98,7 +98,7 @@ const summary = async (teams: TradeTeams): Promise<TradeSummary> => {
 		if (i == 1) {
 			const tradeToUpdate = (await idb.cache.trade.get(0))!;
 			tradeToUpdate.teams[1].ovrAfter = s.teams[1].ovrAfter;
-			await idb.cache.trade.put({ ...tradeToUpdate });
+			await idb.cache.trade.put(tradeToUpdate);
 		}
 	}
 

--- a/src/worker/core/trade/summary.ts
+++ b/src/worker/core/trade/summary.ts
@@ -3,17 +3,6 @@ import { idb } from "../../db";
 import { g, helpers } from "../../util";
 import type { Player, TradeSummary, TradeTeams } from "../../../common/types";
 
-export const getTeamOvr = async (playersRaw: Player[]) => {
-	const players = await idb.getCopies.playersPlus(playersRaw, {
-		attrs: ["value", "pid"],
-		fuzz: true,
-		ratings: ["ovr", "pos", "ovrs"],
-		season: g.get("season"),
-	});
-
-	return team.ovr(players);
-};
-
 /**
  * Create a summary of the trade, for eventual display to the user.
  *
@@ -86,7 +75,7 @@ const summary = async (teams: TradeTeams): Promise<TradeSummary> => {
 		}
 
 		const j = i === 0 ? 1 : 0;
-		s.teams[j].ovrBefore = await getTeamOvr(playersBefore);
+		s.teams[j].ovrBefore = team.ovr(playersBefore);
 
 		playersAfter[j].push(
 			...playersBefore.filter(p => !pids[i].includes(p.pid)),
@@ -94,7 +83,7 @@ const summary = async (teams: TradeTeams): Promise<TradeSummary> => {
 		playersAfter[i].push(...playersBefore.filter(p => pids[i].includes(p.pid)));
 	}
 	for (const i of [0, 1] as const) {
-		s.teams[i].ovrAfter = await getTeamOvr(playersAfter[i]);
+		s.teams[i].ovrAfter = team.ovr(playersAfter[i]);
 	}
 
 	const overCap = [false, false];

--- a/src/worker/core/trade/summary.ts
+++ b/src/worker/core/trade/summary.ts
@@ -95,6 +95,11 @@ const summary = async (teams: TradeTeams): Promise<TradeSummary> => {
 	}
 	for (const i of [0, 1] as const) {
 		s.teams[i].ovrAfter = await getTeamOvr(playersAfter[i]);
+		if (i == 1) {
+			const tradeToUpdate = (await idb.cache.trade.get(0))!;
+			tradeToUpdate.teams[1].ovrAfter = s.teams[1].ovrAfter;
+			await idb.cache.trade.put({ ...tradeToUpdate });
+		}
 	}
 
 	const overCap = [false, false];

--- a/src/worker/core/trade/summary.ts
+++ b/src/worker/core/trade/summary.ts
@@ -3,7 +3,7 @@ import { idb } from "../../db";
 import { g, helpers } from "../../util";
 import type { Player, TradeSummary, TradeTeams } from "../../../common/types";
 
-const getTeamOvr = async (playersRaw: Player[]) => {
+export const getTeamOvr = async (playersRaw: Player[]) => {
 	const players = await idb.getCopies.playersPlus(playersRaw, {
 		attrs: ["value", "pid"],
 		fuzz: true,
@@ -95,11 +95,6 @@ const summary = async (teams: TradeTeams): Promise<TradeSummary> => {
 	}
 	for (const i of [0, 1] as const) {
 		s.teams[i].ovrAfter = await getTeamOvr(playersAfter[i]);
-		if (i == 1) {
-			const tradeToUpdate = (await idb.cache.trade.get(0))!;
-			tradeToUpdate.teams[1].ovrAfter = s.teams[1].ovrAfter;
-			await idb.cache.trade.put(tradeToUpdate);
-		}
 	}
 
 	const overCap = [false, false];


### PR DESCRIPTION
A second go-around of trying this "trade AI should reevaluate the draft pick values they are giving up when changing team OVRs". It doesn't change the cache this time (uses some extra storage, but doesn't modify what was being stored before), just does some reevaluation, haven't seen much of a difference in speed for "Ask for Trade Proposals" when testing. 

Testing Conducted:
For reference, here are the starting team ratings: https://imgur.com/5zubF50

On the master branch, teams are willing to give up 1st round picks even when their team OVR tanks to < 40: https://imgur.com/abL2ZIZ

One team is willing to do this trade that tanks their team OVR to -36 while also giving up 2 immediate 1sts. Not to mention also give up a ton of value in players: https://imgur.com/V8ZbWJj

On the feature branch, teams are not willing to tank their OVR as much when giving up 1sts, the lowest I see is 50 OVR which would be around the 10th pick: https://imgur.com/iSpNqeQ. Generally the trades look more realistic to me. 

The same team from before is willing to give up much less but still make what I consider a pretty reasonable trade: https://imgur.com/9QMRfue