### PR TITLE
Only dynamically update pick value when trading with user

### DIFF
--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -190,8 +190,9 @@ const getPickNumber = async (
 		estPick = dp.pick;
 	} else {
 		let temp = cache.estPicks[dp.originalTid];
-		// if trading with the user, make sure the pick is accurately judged
+		// if trading with the user, make sure the AI pick is accurately judged
 		// based on what players are outgoing in the trade
+		// and just use the cached estimated pick if no players are being exchanged
 		if (
 			tid != g.get("userTid") &&
 			dp.originalTid === tid &&
@@ -637,7 +638,10 @@ const getModifiedPickRank = async (
 	pidsAdd: number[],
 	pidsRemove: number[],
 ) => {
+	// later we need to find the new ranks of this team's ovr/estimated win%
+	// it's cleaner to determine this by temporarily removing the old team info from the cached lists
 	const newTeamOvrs = cache.teamOvrs.filter(t => t.tid != tid);
+	// we know this team's old proj win%'s index based on what their old estimated pick was
 	const newWps = cache.wps.filter((wp, i) => i != cache.estPicks[tid] - 1);
 	const teamSeason = await idb.cache.teamSeasons.indexGet(
 		"teamSeasonsBySeasonTid",

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -633,7 +633,7 @@ const getModifiedPickRank = async (
 		"teamSeasonsBySeasonTid",
 		[tid, g.get("season")],
 	);
-	const teams = g.get("numActiveTeams");
+	const numActiveTeams = g.get("numActiveTeams");
 	const gp = teamSeason?.gp ?? 0;
 	const seasonFraction = gp / g.get("numGames");
 
@@ -656,11 +656,12 @@ const getModifiedPickRank = async (
 	}));
 
 	const newTeamOvr = team.ovr(playerRatings);
-	const newTeamOvrRank =
+	const newTeamOvrIndex =
 		newTeamOvr < cache.teamOvrs[cache.teamOvrs.length - 1].ovr
 			? cache.teamOvrs.length - 1
 			: cache.teamOvrs.findIndex(t => t.ovr < newTeamOvr);
-	const newTeamOvrWinp = 0.25 + (0.5 * (teams - 1 - newTeamOvrRank)) / teams;
+	const newTeamOvrWinp =
+		0.25 + (0.5 * (numActiveTeams - 1 - newTeamOvrIndex)) / numActiveTeams;
 	const newWp =
 		gp === 0
 			? newTeamOvrWinp

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -634,8 +634,7 @@ const getModifiedPickRank = async (
 		[tid, g.get("season")],
 	);
 	const teams = g.get("numActiveTeams");
-	const record = teamSeason ? [teamSeason.won, teamSeason.lost] : [0, 0];
-	const gp = record[0] + record[1];
+	const gp = teamSeason?.gp ?? 0;
 	const seasonFraction = gp / g.get("numGames");
 	const players = await idb.cache.players.indexGetAll("playersByTid", tid);
 	let playerRatings = players.map(p => ({
@@ -675,7 +674,7 @@ const getModifiedPickRank = async (
 	const newWp =
 		gp === 0
 			? newTeamOvrWinp
-			: seasonFraction * (record[0] / gp) +
+			: seasonFraction * ((teamSeason?.won ?? 0) / gp) +
 			  (1 - seasonFraction) * newTeamOvrWinp;
 	const newRank =
 		newWp > cache.wps[cache.wps.length - 1]

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -198,7 +198,7 @@ const getPickNumber = async (
 		// based on what players are outgoing in the trade
 		// and just use the cached estimated pick if no players are being exchanged
 		if (
-			tid != g.get("userTid") &&
+			tid !== g.get("userTid") &&
 			dp.originalTid === tid &&
 			tradingPartnerTid === g.get("userTid") &&
 			pidsAdd.length + pidsRemove.length > 0
@@ -646,7 +646,7 @@ const getModifiedPickRank = async (
 	// it's cleaner to determine this by temporarily removing the old team info from the cached lists
 	const newTeamOvrs = cache.teamOvrs.filter(t => t.tid !== tid);
 	// we know this team's old proj win%'s index based on what their old estimated pick was
-	const newWps = cache.wps.filter(w => w.tid != tid);
+	const newWps = cache.wps.filter(w => w.tid !== tid);
 	const teamSeason = await idb.cache.teamSeasons.indexGet(
 		"teamSeasonsBySeasonTid",
 		[tid, g.get("season")],

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -48,7 +48,8 @@ const ovrIndexToEstWinPercent = (teamOvrIndex: number) => {
 	return (
 		0.25 +
 		(0.5 * (g.get("numActiveTeams") - 1 - teamOvrIndex)) /
-			g.get("numActiveTeams")
+			g.get("numActiveTeams") -
+		1
 	);
 };
 
@@ -517,7 +518,7 @@ const refreshCache = async () => {
 		let teamOvrIndex = teamOvrs.findIndex(t2 => t2.tid === t.tid);
 		if (teamOvrIndex < 0) {
 			// This happens if a team has no players on it - just assume they are the worst
-			teamOvrIndex = teamOvrs.length;
+			teamOvrIndex = teamOvrs.length - 1;
 		}
 
 		// 25% to 75% based on rank
@@ -640,7 +641,7 @@ const getModifiedPickRank = async (
 ) => {
 	// later we need to find the new ranks of this team's ovr/estimated win%
 	// it's cleaner to determine this by temporarily removing the old team info from the cached lists
-	const newTeamOvrs = cache.teamOvrs.filter(t => t.tid != tid);
+	const newTeamOvrs = cache.teamOvrs.filter(t => t.tid !== tid);
 	// we know this team's old proj win%'s index based on what their old estimated pick was
 	const newWps = cache.wps.filter((wp, i) => i != cache.estPicks[tid] - 1);
 	const teamSeason = await idb.cache.teamSeasons.indexGet(

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -182,6 +182,8 @@ const getPickNumber = async (
 		estPick = dp.pick;
 	} else {
 		let temp = cache.estPicks[dp.originalTid];
+		// if trading with the user, make sure the pick is accurately judged
+		// based on what players are outgoing in the trade
 		if (
 			tid != g.get("userTid") &&
 			dp.originalTid === tid &&
@@ -627,7 +629,6 @@ const getModifiedPickRank = async (
 	pidsAdd: number[],
 	pidsRemove: number[],
 ) => {
-	console.log("Hit!");
 	const teamSeason = await idb.cache.teamSeasons.indexGet(
 		"teamSeasonsBySeasonTid",
 		[tid, g.get("season")],

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -678,7 +678,7 @@ const getModifiedPickRank = async (
 			: seasonFraction * (record[0] / gp) +
 			  (1 - seasonFraction) * newTeamOvrWinp;
 	const newRank =
-		newWp > cache.wps[cache.wps.length]
+		newWp > cache.wps[cache.wps.length - 1]
 			? cache.wps.length
 			: cache.wps.findIndex(wp => newWp < wp) + 1;
 	return newRank;

--- a/src/worker/core/team/valueChange.ts
+++ b/src/worker/core/team/valueChange.ts
@@ -699,7 +699,7 @@ const getModifiedPickRank = async (
 			: seasonFraction * (record[0] / gp) +
 			  (1 - seasonFraction) * newTeamOvrWinp;
 	const newRank =
-		newWp > cache.wps[cache.wps.length]
+		newWp > cache.wps[cache.wps.length - 1]
 			? cache.wps.length
 			: cache.wps.findIndex(wp => newWp < wp) + 1;
 	if (addAssetKey != undefined) {

--- a/src/worker/core/trade/makeItWork.ts
+++ b/src/worker/core/trade/makeItWork.ts
@@ -117,6 +117,7 @@ const tryAddAsset = async (
 		return;
 	}
 
+	const addAssetKey = Math.random();
 	// Calculate the value for each asset added to the trade, for use in forward selection
 	for (const asset of assets) {
 		const userPids = teams[0].pids.slice();
@@ -144,6 +145,7 @@ const tryAddAsset = async (
 			otherDpids,
 			valueChangeKey,
 			teams[0].tid,
+			asset.type === "draftPick" ? addAssetKey : undefined,
 		);
 	}
 	assets.sort((a, b) => b.dv - a.dv); // Find the asset that will push the trade value the smallest amount above 0

--- a/src/worker/core/trade/makeItWork.ts
+++ b/src/worker/core/trade/makeItWork.ts
@@ -117,7 +117,6 @@ const tryAddAsset = async (
 		return;
 	}
 
-	const addAssetKey = Math.random();
 	// Calculate the value for each asset added to the trade, for use in forward selection
 	for (const asset of assets) {
 		const userPids = teams[0].pids.slice();
@@ -145,7 +144,6 @@ const tryAddAsset = async (
 			otherDpids,
 			valueChangeKey,
 			teams[0].tid,
-			asset.type === "draftPick" ? addAssetKey : undefined,
 		);
 	}
 	assets.sort((a, b) => b.dv - a.dv); // Find the asset that will push the trade value the smallest amount above 0


### PR DESCRIPTION
Same concept/results/testing as all the other PRs I made

Almost all of the previous trade logic is also retained, so not a big diff for this one

The difference in this one is the AI only reevaluates picks in the trade when trading with the user - in AI-to-AI trades the previous behavior is retained

There seems to be some precedent for this type of thing as I see this as adding onto the previous logic of the AI applying "fuzz" as I see 
`if (tradeWithUser && seasons > 0) {
			if (usersPick) {
				// Penalty for user draft picks
				const difficultyFactor = 1 + 1.5 * g.get("difficulty");
				estPick = helpers.bound(
					Math.round((estPick + numPicksPerRound / 3.5) * difficultyFactor),
					1,
					numPicksPerRound,
				);
			} else {
				// Bonus for AI draft picks
				estPick = helpers.bound(
					Math.round(estPick - numPicksPerRound / 3.5),
					1,
					numPicksPerRound,
				);
			}
		}`

draft picks are valued differently if the AI is trading with the user