### PR TITLE
Fix path resolution for local build on Windows

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json",
-    "extraFileExtensions": [".mjs"]
+    "extraFileExtensions": [".mjs"],
+    "tsconfigRootDir": "./"
   },
   "ignorePatterns": ["src/worker/ajvHack/esbuild.js"],
   "env": {

--- a/tools/lib/getDirname.js
+++ b/tools/lib/getDirname.js
@@ -1,0 +1,9 @@
+import { fileURLToPath } from "node:url";
+import path from "path";
+
+const getDirname = url => {
+	const fileURL = fileURLToPath(new URL(url));
+	return path.dirname(fileURL);
+};
+
+export { getDirname };

--- a/tools/lib/getDirname.js
+++ b/tools/lib/getDirname.js
@@ -1,8 +1,8 @@
 import { fileURLToPath } from "node:url";
-import path from "path";
+import path from "node:path";
 
 const getDirname = url => {
-	const fileURL = fileURLToPath(new URL(url));
+	const fileURL = fileURLToPath(url);
 	return path.dirname(fileURL);
 };
 

--- a/tools/lib/rollupConfig.js
+++ b/tools/lib/rollupConfig.js
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import alias from "@rollup/plugin-alias";
 import { babel } from "@rollup/plugin-babel";
 import blacklist from "rollup-plugin-blacklist";
@@ -20,8 +21,10 @@ export default (nodeEnv, { blacklistOptions, statsFilename, legacy } = {}) => {
 		process.env.NODE_ENV = nodeEnv;
 	}
 
-	const __dirname = path.dirname(new URL(import.meta.url).pathname);
-	const root = path.resolve(__dirname, "../..");
+	const __dirname = path.dirname(
+		path.normalize(fileURLToPath(import.meta.url)),
+	);
+	const root = path.normalize(path.join(__dirname, "..", ".."));
 
 	const plugins = [
 		alias({

--- a/tools/lib/rollupConfig.js
+++ b/tools/lib/rollupConfig.js
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import alias from "@rollup/plugin-alias";
 import { babel } from "@rollup/plugin-babel";
 import blacklist from "rollup-plugin-blacklist";
@@ -10,6 +9,7 @@ import replace from "@rollup/plugin-replace";
 import terser from "@rollup/plugin-terser";
 import { visualizer } from "rollup-plugin-visualizer";
 import { getSport } from "./buildFuncs.js";
+import { getDirname } from "./getDirname.js";
 
 const extensions = [".mjs", ".js", ".json", ".node", ".ts", ".tsx"];
 
@@ -21,10 +21,8 @@ export default (nodeEnv, { blacklistOptions, statsFilename, legacy } = {}) => {
 		process.env.NODE_ENV = nodeEnv;
 	}
 
-	const __dirname = path.dirname(
-		path.normalize(fileURLToPath(import.meta.url)),
-	);
-	const root = path.normalize(path.join(__dirname, "..", ".."));
+	const __dirname = getDirname(import.meta.url);
+	const root = path.join(__dirname, "..", "..");
 
 	const plugins = [
 		alias({

--- a/tools/lib/watchJS.js
+++ b/tools/lib/watchJS.js
@@ -2,7 +2,7 @@ import path from "node:path";
 import { Worker } from "node:worker_threads";
 import { getDirname } from "./getDirname.js";
 
-const __dirname = getDirname(new URL(import.meta.url));
+const __dirname = getDirname(import.meta.url);
 
 const watchJS = (updateStart, updateEnd, updateError) => {
 	for (const name of ["ui", "worker"]) {

--- a/tools/lib/watchJS.js
+++ b/tools/lib/watchJS.js
@@ -1,7 +1,8 @@
 import path from "node:path";
 import { Worker } from "node:worker_threads";
+import { getDirname } from "./getDirname.js";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = getDirname(new URL(import.meta.url));
 
 const watchJS = (updateStart, updateEnd, updateError) => {
 	for (const name of ["ui", "worker"]) {

--- a/tools/names-gen-basketball-football.js
+++ b/tools/names-gen-basketball-football.js
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { getDirname } from "./lib/getDirname.js";
 
-const __dirname = getDirname(new URL(import.meta.url));
+const __dirname = getDirname(import.meta.url);
 
 const basketball = namesBasketball();
 fs.writeFileSync(

--- a/tools/names-gen-basketball-football.js
+++ b/tools/names-gen-basketball-football.js
@@ -2,8 +2,9 @@ import namesBasketball from "./lib/namesBasketball.js";
 import namesFootball from "./lib/namesFootball.js";
 import fs from "node:fs";
 import path from "node:path";
+import { getDirname } from "./lib/getDirname.js";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = getDirname(new URL(import.meta.url));
 
 const basketball = namesBasketball();
 fs.writeFileSync(

--- a/tools/names.js
+++ b/tools/names.js
@@ -1,9 +1,10 @@
 import { csvParse } from "d3-dsv";
 import fs from "node:fs";
 import path from "node:path";
+import { getDirname } from "./lib/getDirname.js";
 import { JSONstringifyOrder, filterAndOutput } from "./lib/namesHelpers.js";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = getDirname(new URL(import.meta.url));
 
 const countryFreqs = ({ fnsByCountry }) => {
 	return Object.fromEntries(

--- a/tools/names.js
+++ b/tools/names.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import { getDirname } from "./lib/getDirname.js";
 import { JSONstringifyOrder, filterAndOutput } from "./lib/namesHelpers.js";
 
-const __dirname = getDirname(new URL(import.meta.url));
+const __dirname = getDirname(import.meta.url);
 
 const countryFreqs = ({ fnsByCountry }) => {
 	return Object.fromEntries(

--- a/tools/races.js
+++ b/tools/races.js
@@ -1,8 +1,9 @@
 import { csvParse } from "d3-dsv";
 import fs from "node:fs";
 import path from "node:path";
+import { getDirname } from "./lib/getDirname.js";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = getDirname(new URL(import.meta.url));
 
 const csv = fs.readFileSync(path.join(__dirname, "races.csv"), "utf8");
 const rows = csvParse(csv);
@@ -32,14 +33,14 @@ const defaultRaces: Record<string, Record<Race, number>> = ${JSON.stringify(
 )};
 
 if (isSport("hockey")) {
-	defaultRaces.USA = {
-		asian: 2,
-		black: 2,
-		brown: 3,
-		white: 93,
-	};
-	defaultRaces.Germany = defaultRaces.USA;
-	defaultRaces.Spain = defaultRaces.USA;
+    defaultRaces.USA = {
+        asian: 2,
+        black: 2,
+        brown: 3,
+        white: 93,
+    };
+    defaultRaces.Germany = defaultRaces.USA;
+    defaultRaces.Spain = defaultRaces.USA;
 }
 
 `;

--- a/tools/races.js
+++ b/tools/races.js
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { getDirname } from "./lib/getDirname.js";
 
-const __dirname = getDirname(new URL(import.meta.url));
+const __dirname = getDirname(import.meta.url);
 
 const csv = fs.readFileSync(path.join(__dirname, "races.csv"), "utf8");
 const rows = csvParse(csv);
@@ -33,14 +33,14 @@ const defaultRaces: Record<string, Record<Race, number>> = ${JSON.stringify(
 )};
 
 if (isSport("hockey")) {
-    defaultRaces.USA = {
-        asian: 2,
-        black: 2,
-        brown: 3,
-        white: 93,
-    };
-    defaultRaces.Germany = defaultRaces.USA;
-    defaultRaces.Spain = defaultRaces.USA;
+	defaultRaces.USA = {
+		asian: 2,
+		black: 2,
+		brown: 3,
+		white: 93,
+	};
+	defaultRaces.Germany = defaultRaces.USA;
+	defaultRaces.Spain = defaultRaces.USA;
 }
 
 `;


### PR DESCRIPTION
Addresses the file pathing issue when attempting to compile or start a local build. 
Added `fileURLToPath` to convert the file URL to a file path string, which is compatible with both Unix and Windows systems.

I was able to run `yarn run build` and `yarn run start` on my local Windows and Linux operating systems successfully after the change.