### PR TITLE
Update coaching impact to be additive instead of multiplicative

### DIFF
--- a/src/worker/core/player/developSeason.basketball.ts
+++ b/src/worker/core/player/developSeason.basketball.ts
@@ -168,6 +168,7 @@ const ratingsFormulas: Record<Exclude<RatingKey, "hgt">, RatingFormula> = {
 
 const calcBaseChange = (age: number, coachingRank: number): number => {
 	let val: number;
+	let variance: number;
 
 	if (age <= 21) {
 		val = 2;
@@ -189,24 +190,24 @@ const calcBaseChange = (age: number, coachingRank: number): number => {
 		val = -6;
 	}
 
-	// Noise
+	// Age based variance
 	if (age <= 23) {
 		val += helpers.bound(random.realGauss(0, 5), -4, 20);
+		variance = 20;
 	} else if (age <= 25) {
 		val += helpers.bound(random.realGauss(0, 5), -4, 10);
+		variance = 12;
 	} else {
 		val += helpers.bound(random.realGauss(0, 3), -2, 4);
+		variance = 8;
 	}
 
 	// Modulate by coaching. g.get("numActiveTeams") doesn't exist when upgrading DB, but that doesn't matter
 	if (Object.hasOwn(g, "numActiveTeams")) {
 		const numActiveTeams = g.get("numActiveTeams");
 		if (numActiveTeams > 1) {
-			if (val >= 0) {
-				val *= ((coachingRank - 1) * -0.5) / (numActiveTeams - 1) + 1.25;
-			} else {
-				val *= ((coachingRank - 1) * 0.5) / (numActiveTeams - 1) + 0.75;
-			}
+			// Vary base change by up to 25% of variance
+			val += (((coachingRank - 1) * -0.5) / (numActiveTeams - 1) + 0.25) * variance;
 		}
 	}
 


### PR DESCRIPTION
I was looking at the player development code and noticed that the impact of coaching rank is purely multiplicative, as opposed to additive. This seems like a fairly non-realistic model - if our random model calculates no base change, the worst coaching and best coaching will have no impact on that player's improvement season to season. From a real coaching perspective, coaching should not disproportionately only benefit players that are already growing a lot. There should be an impact on player growth between the worst and best coaching staff, no matter whether they are on the progression scale. 

The exact numbers for the additive affect are up for debate, I've gone with an age derived factor of max +/- 5, 3, and 2 for <23, <25, and others, respectively. 

(As a separate point, it is surprising to me that the base prog for a player is calculated only once across the board - it could make sense to split physical, skill, and shooting skills into separate calcs with different curves altogether IMO, to enable more diverse player development instead of the general homogeneity we see in top level BBGM players today - I may cut a separate PR for that). 


<img width="593" alt="image" src="https://user-images.githubusercontent.com/14138927/233717336-a5ca3d7e-9fa9-4653-b97d-cb828885ad25.png">
