### PR TITLE
update esbuild to work with babel

### DIFF
--- a/tools/lib/esbuildConfig.js
+++ b/tools/lib/esbuildConfig.js
@@ -1,8 +1,9 @@
 import fs from "fs/promises";
 import babel from "@babel/core";
 import babelPluginSyntaxTypescript from "@babel/plugin-syntax-typescript";
-import babelPluginSportFunctions from "../babel-plugin-sport-functions/index.cjs";
-import { getSport } from "./buildFuncs.js";
+import babelPluginSportFunctions from "../babel-plugin-sport-functions/index.js";
+import getSport from "./getSport.js";
+import path from "path";
 
 const babelCache = {};
 
@@ -10,48 +11,42 @@ const babelCache = {};
 const pluginSportFunctions = nodeEnv => ({
 	name: "sport-functions",
 	setup(build) {
-		build.onLoad({ filter: /\.tsx?$/, namespace: "file" }, async args => {
+		build.onResolve({ filter: /\..{1,}Sport/ }, async args => {
+			return {
+				path: path.join(args.resolveDir, args.path) + ".ts",
+				namespace: "by-sport",
+			};
+		});
+
+		build.onLoad({ filter: /\.tsx?$/, namespace: "by-sport" }, async args => {
 			const { mtimeMs } = await fs.stat(args.path);
 			if (babelCache[args.path] && babelCache[args.path].mtimeMs === mtimeMs) {
 				return babelCache[args.path].result;
 			}
 
-			const isTSX = args.path.endsWith("tsx");
-
-			const loader = isTSX ? "tsx" : "ts";
+			const loader = args.path.endsWith("tsx") ? "tsx" : "ts";
 
 			const text = await fs.readFile(args.path, "utf8");
 
 			// result is undefined if no match, meaning just do normal stuff
-			let result;
-			if (
-				text.includes("bySport") ||
-				(nodeEnv === "production" && text.includes("isSport"))
-			) {
-				const contents = (
-					await babel.transformAsync(text, {
-						babelrc: false,
-						configFile: false,
-						sourceMaps: "inline",
-						plugins: [
-							[babelPluginSyntaxTypescript, { isTSX }],
-							babelPluginSportFunctions,
-						],
-					})
-				).code;
+			const contents = (
+				await babel.transformAsync(text, {
+					babelrc: false,
+					configFile: false,
+					sourceMaps: "inline",
+					plugins: [
+						[babelPluginSyntaxTypescript, { isTSX: true }],
+						babelPluginSportFunctions,
+					],
+				})
+			).code;
 
-				result = { contents, loader };
-			}
+			const result = { contents, loader };
 
 			babelCache[args.path] = {
 				mtimeMs,
 				result,
 			};
-
-			if (result === undefined) {
-				// Might as well return the text, since we have it in memory already
-				result = { contents: text, loader };
-			}
 
 			return result;
 		});
@@ -69,16 +64,15 @@ const esbuildConfig = ({ nodeEnv, name }) => {
 		outfile,
 		bundle: true,
 		sourcemap: true,
-		jsx: "automatic",
-		jsxDev: nodeEnv === "development",
+		inject: ["tools/lib/react-shim.mjs"],
 		define: {
 			"process.env.NODE_ENV": JSON.stringify(nodeEnv),
 			"process.env.SPORT": JSON.stringify(sport),
 		},
 		plugins: [pluginSportFunctions(nodeEnv)],
 
-		// This is needed because dropbox conditionally requries various node builtins, and esbuild chokes on that even though it never actually makes it to the browser
-		external: name === "ui" ? ["crypto", "util"] : undefined,
+		// This is needed because dropbox conditionally requries various node builtins, and esbuild chokes on that even though it never actually makes it to the browser. Skip it for the worker though, otherwise that introduces a spurious error because the type export in worker/index.ts results in a module.exports being added.
+		platform: name === "ui" ? "node" : undefined,
 	};
 };
 


### PR DESCRIPTION
## Summary
It was noticed that errors were being improperly reported when trying to debug the code. This was due to an issue with the esbuild configuration, and the babel plugin callbacks used during bundling.

[See the discussion here](https://github.com/zengm-games/zengm/issues/426)

---

## Description
1. It was noticed that any files that used babel to inline `bySport` or `isSport` configurations were being listed as `unknown` in the debugger. It was also noticed that these babel transformed files were unlisted within the debugger. 

    To solved this issue, a [`onResolve` callback](https://esbuild.github.io/plugins/#on-resolve) was added to the esbuild plugin function defined in the configuration.

---

2. Once the `onResolve` callback was added, we needed to make sure that the files being filtered by the callback were transformed properly. 

    To solve this problem, we added a namespace field to the `onResolve` callback result, and filtered files that passed through the `onLoad` callback to files within the namespace set during `onResolve`. 

---

3. Finally, as good practice, dead code was removed from the `onLoad` callback. 

    Now that only certain files were being passed through the `onLoad` callback, we no longer need to check if the file should be babel transformed. We removed logic to filter out files to be transformed or not, since the only files coming through to the onLoad callback need to be transformed.

---

### Continuing the Discussion

- Make sure ldrobner's fork is up to date
- Check in and validate results
- Finish code clean up