### PR TITLE
Add logo in center field in live football games

### DIFF
--- a/src/ui/components/BoxScore.football.tsx
+++ b/src/ui/components/BoxScore.football.tsx
@@ -408,9 +408,20 @@ const ScoringSummary = memo(
 const NUM_SECTIONS = 12;
 const DEFAULT_HEIGHT = 200;
 
-const FieldBackground = ({ t, t2 }: { t: Team; t2: Team }) => {
+const FieldBackground = ({ t, t2, hT }: { t: Team; t2: Team; hT: string }) => {
+	const styles: CSSProperties = {
+		height: "100%",
+		width: "100%",
+		backgroundImage: "url(" + hT + ")",
+		backgroundRepeat: "no-repeat",
+		backgroundPosition: "center",
+		backgroundSize: `${(1 / 12) * 100}%`,
+		tabSize: 0,
+		position: "absolute",
+	};
 	return (
 		<div className="d-flex align-items-stretch position-absolute w-100 h-100">
+			<div style={styles}></div>
 			{range(NUM_SECTIONS).map(i => {
 				const style: CSSProperties = {
 					width: `${(1 / 12) * 100}%`,
@@ -740,7 +751,11 @@ const FieldAndDrive = ({
 					minHeight: DEFAULT_HEIGHT,
 				}}
 			>
-				<FieldBackground t={boxScore.teams[0]} t2={boxScore.teams[1]} />
+				<FieldBackground
+					t={boxScore.teams[0]}
+					t2={boxScore.teams[1]}
+					hT={boxScore.teams[1].imgURL}
+				/>
 				{!sportState.newPeriodText ? (
 					<>
 						<VerticalLine


### PR DESCRIPTION
![image](https://github.com/zengm-games/zengm/assets/57536929/84d26173-6d84-4ce4-baf0-4de7959e9e24)

Made changes to make it up to date with master, instead of a pull request to the other field-and-drive branch.