### PR TITLE
Improve distribution of trade impact

### DIFF
--- a/src/worker/core/trade/processTrade.ts
+++ b/src/worker/core/trade/processTrade.ts
@@ -105,10 +105,13 @@ const processTrade = async (
 
 			if (teamSeason) {
 				// Bad players do not actually count as a "player traded away"
-				teamSeason.numPlayersTradedAway += helpers.sigmoid(
-					p.valueNoPot / 100,
-					30,
-					0.47,
+				teamSeason.numPlayersTradedAway += 1.4 * Math.pow(
+					helpers.sigmoid(
+						p.valueNoPot / 100,
+						20,
+						0.47,
+					), 
+					4
 				);
 			}
 		}


### PR DESCRIPTION
Hi - inspired by the recent Luka trade, I decided to poke around the valuation/calculation of trade impact on player mood. For a few years I've felt that mood impact from low level player trades is fairly outsized, compared to trade impact from star players. 

Looking at the math this hunch seems to check out - the impact of trading a 54ovr player is 90% that of trading a 90ovr league defining player. In reality perceived trade-happiness of a team is much more anchored by the "value" of a player above mean. 

In concrete terms, trading Ty Jerome off Cleveland should not be 90% the impact of Dallas dealing Luka for team mood. I've taken a fairly conservative rescaling approach here, such that the max impact is now 40% higher for a player trade, but making "Ty Jerome" trades is around 40% lower impact. 

Here's a chart illustrating the distribution of trade impacts across a sample league before and after the change. Values are around equal at the 59ovr mark. 

<img width="587" alt="image" src="https://github.com/user-attachments/assets/ae4b5e17-ae2a-4151-86f2-3a074c23a216" />
