### PR TITLE
contract team options

### DIFF
--- a/src/common/getCols.ts
+++ b/src/common/getCols.ts
@@ -2836,6 +2836,7 @@ const cols: {
 		sortSequence: ["desc", "asc"],
 		sortType: "currency",
 	},
+	// JTODO_playerOption: edit this here, could account for player option maybe?
 	"Asking For": {
 		sortSequence: ["desc", "asc"],
 		sortType: "currency",

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -1396,6 +1396,7 @@ const sum = (values: (number | undefined)[]) => {
 };
 
 // If a player was just drafted and the regular season hasn't started, then he can be released without paying anything
+// JTODO: to consider, should players who are just drafted be able to be put under a team option contract when signing them?
 const justDrafted = (
 	p: {
 		draft: {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -233,6 +233,7 @@ export type DraftType =
 
 // Key is team ID receiving this asset
 // Why store name and extra draft pick info? For performance a bit, but mostly in case old players are deleted in a league, the trade event will still show something reasonable
+// JTODO: how will teams think about player options/ team options?
 type TradeEventAsset =
 	| {
 			pid: number;
@@ -969,6 +970,7 @@ export type MoodComponents = {
 
 export type MoodTrait = "F" | "L" | "$" | "W";
 
+// JTODO_playerOption: consider adding a demands for player option? Also, how can this be changed to handle player options?
 export type Negotiation = {
 	pid: number;
 	tid: number;
@@ -1105,11 +1107,17 @@ export type PhaseReturn = {
 	updateEvents?: UpdateEvents;
 };
 
+// JTODO: consider adding here, team contract options/non-tradeable players/ player options.
+// 		  considering the next two, a bit more complex. Options should be a string, player or team
+//		  but if this wants to be expanded it could be?
+export type ContractOption = "team" | "player" | "none";
+
 export type PlayerContract = {
 	amount: number;
 	exp: number;
 	rookie?: true; // If present, this is a rookie contract. Could be either a rookie scale auto sign, or negotiated.
 	rookieResign?: true; // Should only be present during re-signing phase for guys re-signing after rookie contracts, otherwise can't identify if previous contract was a rookie contract cause it's overwritten!
+	option?: ContractOption;
 };
 
 export type PlayerFeatWithoutKey = {

--- a/src/ui/components/contract.tsx
+++ b/src/ui/components/contract.tsx
@@ -58,7 +58,7 @@ export const ContractExp = ({
 
 	const season = useLocal((state) => state.season);
 	const expiring = season === p.contract.exp;
-
+	// JTODO: implement option to offer a team contract here
 	return (
 		<span
 			className={clsx({

--- a/src/ui/views/Negotiation.tsx
+++ b/src/ui/views/Negotiation.tsx
@@ -8,7 +8,7 @@ import {
 	toWorker,
 	useLocalPartial,
 } from "../util";
-import type { View } from "../../common/types";
+import type { ContractOption, View } from "../../common/types";
 import {
 	HelpPopover,
 	Mood,
@@ -30,15 +30,26 @@ const redirectNegotiationOrRoster = async (cancelled: boolean) => {
 	}
 };
 
+// JTODO: this button should actually probably be stored within the Buttons.tsx folder, but temporary for now
+const TeamOption = () => {
+	const button = (
+		<button className="btn btn-secondary" onClick={}>
+			Ask for team option?
+		</button>
+	);
+};
+// JTODO: add option here for team options, like how should it be applied?
 const SignButton = ({
 	pid,
 	amount,
 	exp,
+	option,
 	disabledReason,
 }: {
 	pid: number;
 	amount: number;
 	exp: number;
+	option: ContractOption;
 	disabledReason: string | undefined;
 }) => {
 	const button = (
@@ -50,6 +61,7 @@ const SignButton = ({
 					pid,
 					amount: Math.round(amount * 1000),
 					exp,
+					option,
 				});
 				if (errorMsg !== undefined && errorMsg) {
 					logEvent({
@@ -83,7 +95,6 @@ const SignButton = ({
 };
 
 const widthStyle = { maxWidth: 575 };
-
 const Negotiation = ({
 	capSpace,
 	challengeNoRatings,
@@ -100,6 +111,7 @@ const Negotiation = ({
 	const { gender } = useLocalPartial(["gender"]);
 
 	let message;
+	// JTODO: once a team contrat is accepted, it should be reflected in the salary cap, so that should be taken into account when calculating cap space. It should also just turn it into a one year.
 	if (salaryCapType === "soft") {
 		if (resigning) {
 			message = (

--- a/src/ui/views/Player/TopStuff.tsx
+++ b/src/ui/views/Player/TopStuff.tsx
@@ -333,7 +333,7 @@ const TopStuff = ({
 				}
 			}
 		}
-
+		// JTODO show team options here somehow? Need to see how it shold be done. Also, once a teamOption is finished should convert back to regualr contract
 		contractInfo = (
 			<>
 				{freeAgent ? "Asking for" : "Contract"}:{" "}

--- a/src/worker/api/actions.ts
+++ b/src/worker/api/actions.ts
@@ -4,6 +4,7 @@ import { idb } from "../db";
 import { g, helpers, logEvent, toUI, updateStatus } from "../util";
 import type { Conditions, TradeTeams } from "../../common/types";
 
+// JTODO add here teamOption?
 const negotiate = async (pid: number, conditions: Conditions) => {
 	// If there is no active negotiation with this pid, create it
 	const negotiation = await idb.cache.negotiations.get(pid);

--- a/src/worker/api/index.ts
+++ b/src/worker/api/index.ts
@@ -89,6 +89,7 @@ import type {
 	DunkAttempt,
 	AllStarPlayer,
 	League,
+	ContractOption,
 } from "../../common/types";
 import {
 	addSimpleAndTeamAwardsToAwardsByPlayer,
@@ -142,16 +143,19 @@ import type { LookingFor } from "../core/trade/makeItWork";
 import type { LookingForState } from "../../ui/views/TradingBlock/useLookingForState";
 import { getPlayer } from "../views/player";
 
+// JTODO: add here team options
 const acceptContractNegotiation = async ({
 	pid,
 	amount,
 	exp,
+	option,
 }: {
 	pid: number;
 	amount: number;
 	exp: number;
+	option: ContractOption;
 }) => {
-	return contractNegotiation.accept({ pid, amount, exp });
+	return contractNegotiation.accept({ pid, amount, exp, option });
 };
 
 const addTeam = async () => {

--- a/src/worker/core/contractNegotiation/accept.ts
+++ b/src/worker/core/contractNegotiation/accept.ts
@@ -2,9 +2,9 @@ import { player, team } from "..";
 import cancel from "./cancel";
 import { idb } from "../../db";
 import { g, toUI, recomputeLocalUITeamOvrs } from "../../util";
-import type { PlayerContract } from "../../../common/types";
+import type { ContractOption, PlayerContract } from "../../../common/types";
 import { PHASE } from "../../../common";
-
+// JTODO: need the player to think about team options. This should make the player less likely to accept an offer. Maybe this can be affected by some mood components? (Loyalty === not bothered, Winning & prior seasons === not bothered, Money === bothered, etc.)
 /**
  * Accept the player's offer.
  *
@@ -18,11 +18,13 @@ const accept = async ({
 	pid,
 	amount,
 	exp,
+	option,
 	dryRun,
 }: {
 	pid: number;
 	amount: number;
 	exp: number;
+	option: ContractOption;
 	dryRun?: boolean;
 }) => {
 	const negotiation = await idb.cache.negotiations.get(pid);
@@ -76,12 +78,13 @@ const accept = async ({
 	const contract: PlayerContract = {
 		amount,
 		exp,
+		option,
 	};
 	if (p.contract.rookie && g.get("phase") === PHASE.RESIGN_PLAYERS) {
 		// Not sure if the phase condition is necessary. The purpose of this is for hard cap rookies with rookie contract scale.
 		contract.rookie = true;
 	}
-
+	// JTODO: make sure that options are updated here? Think this is the right place
 	if (!dryRun) {
 		await player.sign(p, g.get("userTid"), contract, g.get("phase"));
 		await idb.cache.players.put(p);

--- a/src/worker/core/phase/newPhaseResignPlayers.ts
+++ b/src/worker/core/phase/newPhaseResignPlayers.ts
@@ -86,7 +86,7 @@ const newPhaseResignPlayers = async (
 	}
 
 	const payrollsByTid = new Map();
-
+	// JTODO: edit team option contracts here. This page might not be the correct place to manage assigning team options.
 	if (g.get("salaryCapType") === "hard") {
 		for (let tid = 0; tid < g.get("numTeams"); tid++) {
 			const payroll = await team.getPayroll(tid);
@@ -96,6 +96,13 @@ const newPhaseResignPlayers = async (
 			payrollsByTid.set(tid, payroll - expiringPayroll);
 		}
 	}
+	// JTODO: get a list of players who are under team options. Should also check if they are on expiring payroll.
+	// Need to add a new button type for accepting a team option? How should the finances change for next season if its not accepted or accepted?
+	// Do we need to add a new phase for this?
+	const pidsUnderTeamOption = new Set();
+	players
+		.filter((p) => p.contract.option === "team")
+		.map((p) => pidsUnderTeamOption.add(p.pid));
 
 	const expiringPids = orderBy(
 		players.filter((p) => p.contract.exp <= g.get("season")),

--- a/src/worker/core/player/contractSeasonsRemaining.ts
+++ b/src/worker/core/player/contractSeasonsRemaining.ts
@@ -1,5 +1,5 @@
 import { g } from "../../util";
-
+// JTODO edit here, see where this is used? Does this need to be edited if the player has an option? Need to do further research as into where this is called. If this is called to determine contracts, should be thought of.
 /**
  * How many seasons are left on this contract? The answer can be a fraction if the season is partially over
  *

--- a/src/worker/core/player/moodComponents.ts
+++ b/src/worker/core/player/moodComponents.ts
@@ -98,6 +98,7 @@ const moodComponents = async (
 		throw new Error(`tid ${tid} not found`);
 	}
 
+	// JTODO: could factor in teamOptions for mood? Not sure about this.
 	const components: MoodComponents = {
 		marketSize: 0,
 		facilities: 0,

--- a/src/worker/core/player/setContract.ts
+++ b/src/worker/core/player/setContract.ts
@@ -7,10 +7,11 @@ import type { PlayerContract, PlayerWithoutKey } from "../../../common/types";
  *
  * @memberOf core.player
  * @param {Object} p Player object.
- * @param {Object} contract Contract object with two properties,    exp (year) and amount (thousands of dollars).
+ * @param {Object} contract Contract object with three properties,    exp (year), amount (thousands of dollars), and option (team | player | none).
  * @param {boolean} signed Is this an official signed contract (true), or just part of a negotiation (false)?
  * @return {Object} Updated player object.
  */
+// JTODO: edit here to include an option
 const setContract = (
 	p: Pick<PlayerWithoutKey, "contract" | "salaries">,
 	contract: PlayerContract,
@@ -31,7 +32,7 @@ const setContract = (
 		if (g.get("phase") > PHASE.AFTER_TRADE_DEADLINE) {
 			start += 1;
 		}
-
+		// JTODO: should this include options? If a team option is set, this probably needs to be expanded
 		for (let i = start; i <= p.contract.exp; i++) {
 			p.salaries.push({
 				season: i,

--- a/src/worker/core/player/sign.ts
+++ b/src/worker/core/player/sign.ts
@@ -4,6 +4,7 @@ import setContract from "./setContract";
 import { g, helpers, logEvent } from "../../util";
 import type { Phase, Player, PlayerContract } from "../../../common/types";
 
+// JTODO: update contract here? Not sure if this is the correct place...
 const sign = async (
 	p: Player,
 	tid: number,

--- a/src/worker/core/trade/makeItWork.ts
+++ b/src/worker/core/trade/makeItWork.ts
@@ -238,7 +238,6 @@ const tryAddAsset = async (
 
 			lookingForSort = true;
 		}
-
 		if (lookingFor.bestCurrentPlayers) {
 			for (const asset of assets) {
 				if (asset.type === "player") {
@@ -340,6 +339,8 @@ const tryAddAsset = async (
  * @param {?Object} estValuesCached Estimated draft pick values from trade.getPickValues, or null. Only pass if you're going to call this repeatedly, then it'll be faster if you cache the values up front.
  * @return {Promise.<?Object>} If it works, resolves to a teams object (similar to first input) with the "made it work" trade info. Otherwise, resolves to undefined
  */
+// JTODO: update the logic around calculating the value for a player with their team option.
+// Should be treated as one year longer than it actually is, and then if the team option is declined, the player should be added to the trade as a free agent.
 const makeItWork = async (
 	teams: TradeTeams,
 	{

--- a/src/worker/db/getCopies/players.ts
+++ b/src/worker/db/getCopies/players.ts
@@ -3,6 +3,7 @@ import { getAll, idb } from "..";
 import { mergeByPk } from "./helpers";
 import { g, helpers } from "../../util";
 import type {
+	ContractOption,
 	GetCopyType,
 	MinimalPlayerRatings,
 	Player,
@@ -54,7 +55,7 @@ export const getPlayersActiveSeason = (
 		};
 	});
 };
-
+// JTODO: get copies of players under options contract? idk could be useful to look for if a player has a player contract.
 const getCopies = async (
 	{
 		pid,
@@ -68,6 +69,7 @@ const getCopies = async (
 		statsTid,
 		tid,
 		watch,
+		option,
 		filter = () => true,
 	}: {
 		pid?: number;
@@ -81,6 +83,7 @@ const getCopies = async (
 		statsTid?: number;
 		tid?: [number, number] | number;
 		watch?: boolean;
+		option?: ContractOption;
 		filter?: (p: Player<MinimalPlayerRatings>) => boolean;
 	} = {},
 	type?: GetCopyType,

--- a/tools/build/generateJsonSchema.ts
+++ b/tools/build/generateJsonSchema.ts
@@ -383,6 +383,11 @@ export const generateJsonSchema = (sport: string) => {
 					rookieResign: {
 						const: true,
 					},
+					// JTODO: do we need a none option for enum? Could just be undefined? Not sure how to write that into this schema
+					option: {
+						type: "string",
+						enum: ["none", "team", "player"],
+					},
 				},
 				required: ["amount", "exp"],
 			},


### PR DESCRIPTION
Seems like there is a decent amount of requests to add options for trading, so I tried to plan out the path of where everything should be modified in order to add teamOptions. I wasn't sure if this should be an issue since I wrote in the code were I thought changes could be made. I assume once teamOptions are added, non-tradeable contracts and player options could probably be added, but I thought it made sense to do them one at a time. Also, this would be a pretty big PR, just from looking at the different parts of the game that would be affected (trade, contracts, mood(?)). I know that this might be something that you do, but if I could help contribute towards this that would be awesome as well 😄 .

benefits:
- more dynamic offseason
- makes resigning more strategic potentially
- trades can be more exciting too

Front end components that would potentially need updates:
- button for applying team options (and probably offering player options, non tradeable clause etc.)
- player card
- wherever contracts are displayed, need to be updated to have a +1
- maybe a new phase for accepting team options? Seems like a lot to have another screen for this though.
- maybe a new column for option type? 

Worker:
- contract logic
- schema for backend
- trade logic