### PR TITLE
Add player notes to RatingsStatsPopover component

### DIFF
--- a/src/ui/components/RatingsStatsPopover/index.tsx
+++ b/src/ui/components/RatingsStatsPopover/index.tsx
@@ -13,34 +13,19 @@ const PlayerNote = ({
 	note: string | undefined;
 	playerName: string | undefined;
 }) => {
-	const [isOpen, setIsOpen] = useState(true);
 	if (!note) {
 		return null;
 	}
 	return (
 		<>
-			<div className="text-body-secondary bold">
-				{" "}
-				Notes {playerName !== undefined ? `for ${playerName}` : ""}
-			</div>
 			<div
 				className="text-wrap"
 				style={{
-					maxHeight: isOpen ? "10em" : "3em",
+					maxHeight: "7em",
 					overflowY: "auto",
 				}}
 			>
 				{note}
-			</div>
-			<div className="d-flex justify-content-end">
-				{note.length > 100 && (
-					<button
-						className="btn btn-sm btn-light-bordered"
-						onClick={() => setIsOpen((prev) => !prev)}
-					>
-						{isOpen ? "less" : "more"}
-					</button>
-				)}
 			</div>
 		</>
 	);
@@ -220,7 +205,11 @@ const RatingsStatsPopover = ({
 
 	const modalHeader = nameBlock;
 	const modalBody = (
-		<RatingsStats ratings={ratings} stats={stats} type={type} />
+		<>
+			<RatingsStats ratings={ratings} stats={stats} type={type} />
+			{note ? <div className="mb-2" /> : null}
+			<PlayerNote note={note} playerName={name} />
+		</>
 	);
 
 	const popoverContent = (
@@ -232,6 +221,7 @@ const RatingsStatsPopover = ({
 		>
 			<div className="mb-2">{nameBlock}</div>
 			<RatingsStats ratings={ratings} stats={stats} type={type} />
+			{note ? <div className="mb-2" /> : null}
 			<PlayerNote note={note} playerName={name} />
 		</div>
 	);

--- a/src/ui/components/RatingsStatsPopover/index.tsx
+++ b/src/ui/components/RatingsStatsPopover/index.tsx
@@ -6,6 +6,46 @@ import { helpers, toWorker } from "../../util";
 import ResponsivePopover from "../ResponsivePopover";
 import { PLAYER } from "../../../common";
 
+const PlayerNote = ({
+	note,
+	playerName,
+}: {
+	note: string | undefined;
+	playerName: string | undefined;
+}) => {
+	const [isOpen, setIsOpen] = useState(true);
+	if (!note) {
+		return null;
+	}
+	return (
+		<>
+			<div className="text-body-secondary bold">
+				{" "}
+				Notes {playerName !== undefined ? `for ${playerName}` : ""}
+			</div>
+			<div
+				className="text-wrap"
+				style={{
+					maxHeight: isOpen ? "10em" : "3em",
+					overflowY: "auto",
+				}}
+			>
+				{note}
+			</div>
+			<div className="d-flex justify-content-end">
+				{note.length > 100 && (
+					<button
+						className="btn btn-sm btn-light-bordered"
+						onClick={() => setIsOpen((prev) => !prev)}
+					>
+						{isOpen ? "less" : "more"}
+					</button>
+				)}
+			</div>
+		</>
+	);
+};
+
 const Icon = ({
 	onClick,
 	ref,
@@ -64,6 +104,7 @@ const RatingsStatsPopover = ({
 		};
 		pid: number;
 		type?: "career" | "current" | "draft" | number;
+		note?: string;
 	}>({
 		pid,
 	});
@@ -107,6 +148,7 @@ const RatingsStatsPopover = ({
 			stats: p.stats,
 			pid,
 			type: p.type,
+			note: p.note,
 		});
 		setLoadingData(false);
 	}, [pid, season]);
@@ -118,8 +160,10 @@ const RatingsStatsPopover = ({
 		}
 	}, [loadData, loadingData]);
 
-	const { abbrev, tid, age, jerseyNumber, name, ratings, stats, type } = player;
+	const { abbrev, tid, age, jerseyNumber, name, ratings, stats, type, note } =
+		player;
 
+	// JTODO: this probably makes a bit more sense as a component instead of a pure jsx function?
 	let nameBlock = null;
 	if (name) {
 		nameBlock = (
@@ -188,6 +232,7 @@ const RatingsStatsPopover = ({
 		>
 			<div className="mb-2">{nameBlock}</div>
 			<RatingsStats ratings={ratings} stats={stats} type={type} />
+			<PlayerNote note={note} playerName={name} />
 		</div>
 	);
 

--- a/src/worker/api/index.ts
+++ b/src/worker/api/index.ts
@@ -2680,7 +2680,7 @@ const ratingsStatsPopoverInfo = async ({
 		hockey: ["keyStatsWithGoalieGP"],
 	});
 
-	const attrs = ["name", "jerseyNumber", "tid", "age"];
+	const attrs = ["name", "jerseyNumber", "tid", "age", "note"];
 	const ratings = ["pos", "ovr", "pot", "season", "tid", ...RATINGS];
 	if (!local.exhibitionGamePlayers) {
 		attrs.push("abbrev");
@@ -2697,7 +2697,7 @@ const ratingsStatsPopoverInfo = async ({
 		oldStats: true,
 		fuzz: true,
 	});
-
+	console.log("this is what is grabbed from p2?", p2);
 	if (actualSeason === undefined) {
 		if (draftProspect) {
 			p2.ratings = p2.ratings[0];
@@ -2708,7 +2708,6 @@ const ratingsStatsPopoverInfo = async ({
 		p2.age = p2.ratings.season - p.born.year;
 
 		p2.stats = p2.careerStats;
-
 		delete p2.careerStats;
 	}
 	if (actualSeason === undefined || actualSeason < currentSeason) {
@@ -2731,7 +2730,6 @@ const ratingsStatsPopoverInfo = async ({
 	} else {
 		type = actualSeason;
 	}
-
 	return {
 		...p2,
 		type,


### PR DESCRIPTION
Added player notes to the popover tab. Can rework the button a bit, and mess with the length of the text box as well. Currently the minimun size is 3em, and the max is set to 10em, with an overflowY component. Additionally, I added a button (which probably should be changed text-wise) for this as well. Addresses TODO here: https://github.com/zengm-games/zengm/blob/e42353eeec2442fbf8047e3fa2fdfb408a349268/TODO#L1037

The images with button are not accurate! Button is deleted but I wanted to keep the images
<img src="https://github.com/user-attachments/assets/4245e604-7d69-4170-9324-fac29e3d348f" alt="short note" width="300">
<img src="https://github.com/user-attachments/assets/509d9df5-7c8a-4c70-b007-07514b6d37b2" alt="Girl in a jacket" width="300">
<img src="https://github.com/user-attachments/assets/02c8a256-9ef4-49b7-bc49-272082a3352a" alt="Girl in a jacket" width="300">
<img src="https://github.com/user-attachments/assets/6e3bb6da-4885-477a-8cf1-20e909c57be4" alt="Girl in a jacket" width="300">
<img src="https://github.com/user-attachments/assets/0a48c440-f0e4-4e06-9d4e-7d94349e2386" alt="responsive layout" width="300">
<img src="https://github.com/user-attachments/assets/dfd35efe-480e-48ed-b303-ff90682c5f0b" alt="iphone SE" width="300">
