### PR TITLE
Update logs to contain total points for players WIP

### DIFF
--- a/src/ui/util/processLiveGameEvents.basketball.tsx
+++ b/src/ui/util/processLiveGameEvents.basketball.tsx
@@ -23,6 +23,7 @@ const getName = (pid: number) => {
 	return playersByPid?.[pid]?.name ?? "???";
 };
 
+// JTODO: add in here! Where the points, rbs, asts, are shown. Just start with points for now, pass in the event object
 export const getText = (
 	event: PlayByPlayEvent,
 	boxScore: {
@@ -146,7 +147,7 @@ export const getText = (
 		event.type === "fgMidRange" ||
 		event.type === "tp"
 	) {
-		texts = ["It's good!"];
+		texts = [`It's good! ${getName(event.pid)} (${event.pidTotalPts} PTS)`];
 	} else if (
 		event.type === "fgLowPostAndOne" ||
 		event.type === "fgMidRangeAndOne" ||
@@ -360,6 +361,7 @@ const processLiveGameEvents = ({
 
 		const eAny = e as any;
 
+		// JTODO: change this maybe so team being controlled is at the top?
 		// Swap teams order, so home team is at bottom in box score
 		const actualT = eAny.t === 0 ? 1 : eAny.t === 1 ? 0 : undefined;
 

--- a/src/worker/core/GameSim.basketball/PlayByPlayLogger.ts
+++ b/src/worker/core/GameSim.basketball/PlayByPlayLogger.ts
@@ -7,6 +7,8 @@ type PlayByPlayEventInputScore =
 			pid: number;
 			pidDefense: number;
 			pidAst: number | undefined;
+			pidTotalPts: number;
+			pidAstTotalAst: number | undefined;
 			clock: number;
 	  }
 	| {
@@ -15,6 +17,8 @@ type PlayByPlayEventInputScore =
 			pid: number;
 			pidDefense: number;
 			pidAst: number | undefined;
+			pidTotalPts: number;
+			pidAstTotalAst: number | undefined;
 			clock: number;
 	  }
 	| {
@@ -22,12 +26,16 @@ type PlayByPlayEventInputScore =
 			t: TeamNum;
 			pid: number;
 			pidAst: number | undefined;
+			pidTotalPts: number;
+			pidAstTotalAst: number | undefined;
 			clock: number;
 	  }
 	| {
 			type: "fgLowPostAndOne";
 			t: TeamNum;
 			pid: number;
+			pidTotalPts: number;
+			pidAstTotalAst: number | undefined;
 			pidAst: number | undefined;
 			clock: number;
 	  }
@@ -35,6 +43,8 @@ type PlayByPlayEventInputScore =
 			type: "fgMidRange";
 			t: TeamNum;
 			pid: number;
+			pidTotalPts: number;
+			pidAstTotalAst: number | undefined;
 			pidAst: number | undefined;
 			clock: number;
 	  }
@@ -42,6 +52,8 @@ type PlayByPlayEventInputScore =
 			type: "fgMidRangeAndOne";
 			t: TeamNum;
 			pid: number;
+			pidTotalPts: number;
+			pidAstTotalAst: number | undefined;
 			pidAst: number | undefined;
 			clock: number;
 	  }
@@ -49,12 +61,15 @@ type PlayByPlayEventInputScore =
 			type: "ft";
 			t: TeamNum;
 			pid: number;
+			pidTotalPts: number;
 			clock: number;
 	  }
 	| {
 			type: "tp";
 			t: TeamNum;
 			pid: number;
+			pidTotalPts: number;
+			pidAstTotalAst: number | undefined;
 			pidAst: number | undefined;
 			clock: number;
 	  }
@@ -62,6 +77,8 @@ type PlayByPlayEventInputScore =
 			type: "tpAndOne";
 			t: TeamNum;
 			pid: number;
+			pidTotalPts: number;
+			pidAstTotalAst: number | undefined;
 			pidAst: number | undefined;
 			clock: number;
 	  }
@@ -69,6 +86,8 @@ type PlayByPlayEventInputScore =
 			type: "fgTipIn";
 			t: TeamNum;
 			pid: number;
+			pidTotalPts: number;
+			pidAstTotalAst: number | undefined;
 			pidAst: number | undefined;
 			clock: number;
 	  }
@@ -76,6 +95,8 @@ type PlayByPlayEventInputScore =
 			type: "fgTipInAndOne";
 			t: TeamNum;
 			pid: number;
+			pidTotalPts: number;
+			pidAstTotalAst: number | undefined;
 			pidAst: number | undefined;
 			clock: number;
 	  }
@@ -83,12 +104,14 @@ type PlayByPlayEventInputScore =
 			type: "fgPutBack";
 			t: TeamNum;
 			pid: number;
+			pidTotalPts: number;
 			clock: number;
 	  }
 	| {
 			type: "fgPutBackAndOne";
 			t: TeamNum;
 			pid: number;
+			pidTotalPts: number;
 			clock: number;
 	  };
 

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -2338,9 +2338,12 @@ class GameSim extends GameSimBase {
 
 		let pAst;
 		let pidAst;
+		let pidTotalPts = this.getStat(this.o, shooter, "pts");
+		let pidAstTotalAst = undefined;
 		if (passer !== undefined) {
 			pAst = this.playersOnCourt[this.o][passer];
 			pidAst = this.team[this.o].player[pAst].id;
+			pidAstTotalAst = this.getStat(this.o, pidAst, "ast");
 		}
 
 		if (type === "tipIn") {
@@ -2352,6 +2355,8 @@ class GameSim extends GameSimBase {
 				pid,
 				pidAst,
 				clock: this.t,
+				pidTotalPts,
+				pidAstTotalAst,
 			});
 		} else if (type === "putBack") {
 			this.recordStat(this.o, p, "fgaAtRim");
@@ -2361,6 +2366,7 @@ class GameSim extends GameSimBase {
 				t: this.o,
 				pid,
 				clock: this.t,
+				pidTotalPts,
 			});
 		} else if (type === "atRim") {
 			// Randomly pick a name to be dunked on
@@ -2382,6 +2388,8 @@ class GameSim extends GameSimBase {
 				pidDefense,
 				pidAst,
 				clock: this.t,
+				pidTotalPts,
+				pidAstTotalAst,
 			});
 		} else if (type === "lowPost") {
 			this.recordStat(this.o, p, "fgaLowPost");
@@ -2392,6 +2400,8 @@ class GameSim extends GameSimBase {
 				pid,
 				pidAst,
 				clock: this.t,
+				pidTotalPts,
+				pidAstTotalAst,
 			});
 		} else if (type === "midRange") {
 			this.recordStat(this.o, p, "fgaMidRange");
@@ -2402,12 +2412,14 @@ class GameSim extends GameSimBase {
 				pid,
 				pidAst,
 				clock: this.t,
+				pidTotalPts,
+				pidAstTotalAst,
 			});
 		} else if (type === "threePointer") {
 			if (g.get("threePointers")) {
 				this.recordStat(this.o, p, "pts"); // Extra point for 3's
 			}
-
+			pidTotalPts = this.getStat(this.o, shooter, "pts"); // Needs to be updated again here, since stat is updated above
 			this.recordStat(this.o, p, "tpa");
 			this.recordStat(this.o, p, "tp");
 			this.playByPlay.logEvent({
@@ -2416,6 +2428,8 @@ class GameSim extends GameSimBase {
 				pid,
 				pidAst,
 				clock: this.t,
+				pidTotalPts,
+				pidAstTotalAst,
 			});
 		}
 
@@ -2709,6 +2723,11 @@ class GameSim extends GameSimBase {
 					t: this.o,
 					pid: this.team[this.o].player[p].id,
 					clock: this.t,
+					pidTotalPts: this.getStat(
+						this.o,
+						this.team[this.o].player[p].id,
+						"pts",
+					),
 				});
 				outcome = "ft";
 				this.recordLastScore(this.o, p, "ft");
@@ -2908,6 +2927,19 @@ class GameSim extends GameSimBase {
 		return array;
 	}
 
+	/**
+	 * Get stat (s) for a player (p) on a team (t).
+	 * @param {number} t Team (0 or 1, this.or or this.d).
+	 * @param {number} p Integer index of this.team[t].player for the player of interest.
+	 * @param {string} s Key for the property of this.team[t].player[p].stat to increment.
+	 */
+	getStat(t: TeamNum, p: number, s: Stat) {
+		if (this.team[t].player[p] !== undefined) {
+			console.log(this.team[t].player[p].stat[s]);
+			return this.team[t].player[p].stat[s];
+		}
+		// return await this.team[t].player[p].stat[s];
+	}
 	/**
 	 * Increments a stat (s) for a player (p) on a team (t) by amount (default is 1).
 	 *

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -2338,7 +2338,7 @@ class GameSim extends GameSimBase {
 
 		let pAst;
 		let pidAst;
-		let pidTotalPts = this.getStat(this.o, shooter, "pts");
+		let pidTotalPts = this.getStat(this.o, p, "pts");
 		let pidAstTotalAst = undefined;
 		if (passer !== undefined) {
 			pAst = this.playersOnCourt[this.o][passer];


### PR DESCRIPTION
Add a proof of concept for total points for a player after making a shot,  Could be expanded to fouls, asts, rbs, and other countable stats. This is somewhat linked to PR #482, because there would be a decent amount of copy and paste needed for this to happen in the `PlayByPlayLogger.ts` in terms of changing types

![image](https://github.com/user-attachments/assets/c031d6ae-f047-423f-87e2-6786fa430283)
updated 
![image](https://github.com/user-attachments/assets/116d2e08-b8fb-4b67-bc42-84ea2a5c7394)

