### PR TITLE
Security: Potential XSS via Unsafe Message HTML Stripping

### DIFF
--- a/src/worker/views/inbox.ts
+++ b/src/worker/views/inbox.ts
@@ -1,4 +1,5 @@
 import { idb } from "../db/index.ts";
+import DOMPurify from "dompurify";
 
 const updateInbox = async () => {
 	const messages = await idb.getCopies.messages();
@@ -6,7 +7,7 @@ const updateInbox = async () => {
 	let anyUnread = false;
 
 	for (const message of messages) {
-		message.text = message.text.replaceAll("<p>", "").replaceAll("</p>", " "); // Needs to be regex otherwise it's cumbersome to do global replace
+		message.text = DOMPurify.sanitize(message.text);
 
 		if (!message.read) {
 			anyUnread = true;


### PR DESCRIPTION
## Summary

Security: Potential XSS via Unsafe Message HTML Stripping

## Problem

**Severity**: `Medium` | **File**: `src/worker/views/inbox.ts:L8`

The inbox worker view (src/worker/views/inbox.ts) removes only <p> and </p> tags from message text, leaving other HTML (e.g., <script>, <img onerror>) intact. If the corresponding UI component does not apply proper sanitization (e.g., using DOMPurify), an attacker who can inject HTML into messages could execute arbitrary JavaScript in the context of the game.

## Solution

Use a robust HTML sanitizer like DOMPurify on all user-generated message content before storage or display. Alternatively, use safe DOM methods (textContent) or a templating engine that escapes HTML by default. Ensure the UI component for inbox messages sanitizes content unconditionally.

## Changes

- `src/worker/views/inbox.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"