### PR TITLE
free agent update

### DIFF
--- a/src/common/defaultGameAttributes.ts
+++ b/src/common/defaultGameAttributes.ts
@@ -159,6 +159,8 @@ export const defaultGameAttributes: GameAttributesLeagueWithHistory = {
 	injuries: undefined,
 	tragicDeaths: undefined,
 	daysLeft: 0, // Used only for free agency
+	freeAgencySigningsPerDay: 0,
+	freeAgencySigningsThisDay: 0,
 	gameOver: false,
 	godMode: false,
 	godModeInPast: false,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -560,6 +560,8 @@ export type GameAttributesLeague = {
 	fantasyPoints?: "standard" | "ppr" | "halfPpr";
 	forceRetireAge: number;
 	forceRetireSeasons: number;
+	freeAgencySigningsPerDay: number;
+	freeAgencySigningsThisDay: number;
 	foulsNeededToFoulOut: number;
 	foulsUntilBonus: [number, number, number];
 	foulRateFactor: number;
@@ -1371,6 +1373,7 @@ export type Local = {
 	playerOvrStd: number;
 	playerOvrMeanStdStale: boolean;
 	playingUntilEndOfRound: boolean;
+	simulatingFreeAgencyDay: boolean;
 	realPlayerActiveSeasons:
 		| Record<
 				string,

--- a/src/ui/views/Settings/settings.tsx
+++ b/src/ui/views/Settings/settings.tsx
@@ -1261,6 +1261,14 @@ export const settings: Setting[] = (
 		},
 		{
 			category: "Contracts",
+			key: "freeAgencySigningsPerDay",
+			name: "Free Agency Signings Per Day",
+			type: "int",
+			description:
+				"During free agency, automatically advance to the next day after this many players are signed league-wide. Set to 0 or -1 to disable.",
+		},
+		{
+			category: "Contracts",
 			key: "playersRefuseToNegotiate",
 			name: "Players Can Refuse To Negotiate",
 			godModeRequired: "always",

--- a/src/ui/views/Settings/types.ts
+++ b/src/ui/views/Settings/types.ts
@@ -23,6 +23,7 @@ export type Key =
 	| "budget"
 	| "aiTradesFactor"
 	| "playersRefuseToNegotiate"
+	| "freeAgencySigningsPerDay"
 	| "injuryRate"
 	| "tragicDeathRate"
 	| "brotherRate"

--- a/src/worker/core/freeAgents/maybeAdvanceDay.ts
+++ b/src/worker/core/freeAgents/maybeAdvanceDay.ts
@@ -1,0 +1,31 @@
+import { PHASE } from "../../../common/constants.ts";
+import play from "./play.ts";
+import { g, lock } from "../../util/index.ts";
+import type { Conditions } from "../../../common/types.ts";
+
+const maybeAdvanceDay = async (conditions: Conditions = {}) => {
+	const threshold = g.get("freeAgencySigningsPerDay");
+	if (threshold <= 0) {
+		return;
+	}
+
+	if (g.get("phase") !== PHASE.FREE_AGENCY) {
+		return;
+	}
+
+	if (g.get("freeAgencySigningsThisDay") < threshold) {
+		return;
+	}
+
+	if (lock.get("gameSim")) {
+		return;
+	}
+
+	if (g.get("daysLeft") <= 0) {
+		return;
+	}
+
+	await play(1, conditions);
+};
+
+export default maybeAdvanceDay;

--- a/src/worker/core/freeAgents/play.ts
+++ b/src/worker/core/freeAgents/play.ts
@@ -4,6 +4,7 @@ import autoSign from "./autoSign.ts";
 import decreaseDemands from "./decreaseDemands.ts";
 import {
 	g,
+	local,
 	lock,
 	updatePlayMenu,
 	updateStatus,
@@ -40,11 +41,19 @@ async function play(
 	const cbRunDay = async () => {
 		// This is called if there are remaining days to simulate
 		const cbYetAnother = async () => {
-			await decreaseDemands();
-			await autoSign();
-			await league.setGameAttributes({
-				daysLeft: g.get("daysLeft") - 1,
-			});
+			local.simulatingFreeAgencyDay = true;
+			try {
+				await league.setGameAttributes({
+					freeAgencySigningsThisDay: 0,
+				});
+				await decreaseDemands();
+				await autoSign();
+				await league.setGameAttributes({
+					daysLeft: g.get("daysLeft") - 1,
+				});
+			} finally {
+				local.simulatingFreeAgencyDay = false;
+			}
 
 			if (g.get("daysLeft") > 0 && numDays > 0) {
 				await toUI("realtimeUpdate", [["playerMovement"]]);

--- a/src/worker/core/freeAgents/recordSigning.ts
+++ b/src/worker/core/freeAgents/recordSigning.ts
@@ -1,0 +1,30 @@
+import { PHASE } from "../../../common/constants.ts";
+import { league } from "../index.ts";
+import { g, local, lock } from "../../util/index.ts";
+
+const recordSigning = async () => {
+	if (local.simulatingFreeAgencyDay) {
+		return;
+	}
+
+	if (g.get("phase") !== PHASE.FREE_AGENCY) {
+		return;
+	}
+
+	const threshold = g.get("freeAgencySigningsPerDay");
+	if (threshold <= 0) {
+		return;
+	}
+
+	const count = g.get("freeAgencySigningsThisDay") + 1;
+	await league.setGameAttributes({
+		freeAgencySigningsThisDay: count,
+	});
+
+	if (count >= threshold && !lock.get("gameSim")) {
+		const { default: maybeAdvanceDay } = await import("./maybeAdvanceDay.ts");
+		void maybeAdvanceDay();
+	}
+};
+
+export default recordSigning;

--- a/src/worker/core/phase/newPhaseFreeAgency.ts
+++ b/src/worker/core/phase/newPhaseFreeAgency.ts
@@ -1,4 +1,4 @@
-import { contractNegotiation, freeAgents, player } from "../index.ts";
+import { contractNegotiation, freeAgents, league, player } from "../index.ts";
 import { helpers } from "../../util/index.ts";
 import type { PhaseReturn } from "../../../common/types.ts";
 import { idb } from "../../db/index.ts";
@@ -29,6 +29,10 @@ const newPhaseFreeAgency = async (): Promise<PhaseReturn> => {
 			await idb.cache.players.put(p);
 		}
 	}
+
+	await league.setGameAttributes({
+		freeAgencySigningsThisDay: 0,
+	});
 
 	return {
 		redirect: {

--- a/src/worker/core/player/sign.ts
+++ b/src/worker/core/player/sign.ts
@@ -58,6 +58,10 @@ const sign = async (
 			type: "freeAgent",
 			eid,
 		});
+
+		const { default: recordSigning } =
+			await import("../freeAgents/recordSigning.ts");
+		await recordSigning();
 	}
 };
 

--- a/src/worker/util/local.ts
+++ b/src/worker/util/local.ts
@@ -20,6 +20,7 @@ const defaultLocal: Local = {
 	realPlayerActiveSeasons: undefined,
 	seasonLeaders: undefined,
 	playingUntilEndOfRound: false,
+	simulatingFreeAgencyDay: false,
 	statusText: "Idle",
 	unviewedSeasonSummary: false, // Set to true when a live game sim of the final game prevents an automatic redirect to the season summary page
 	username: undefined,
@@ -44,6 +45,7 @@ const local: Local & {
 	playerOvrStd: defaultLocal.playerOvrStd,
 	playerOvrMeanStdStale: defaultLocal.playerOvrMeanStdStale,
 	playingUntilEndOfRound: defaultLocal.playingUntilEndOfRound,
+	simulatingFreeAgencyDay: defaultLocal.simulatingFreeAgencyDay,
 	realPlayerActiveSeasons: defaultLocal.realPlayerActiveSeasons,
 	seasonLeaders: defaultLocal.seasonLeaders,
 	statusText: defaultLocal.statusText,
@@ -65,6 +67,7 @@ const local: Local & {
 		local.playerOvrStd = defaultLocal.playerOvrStd;
 		local.playerOvrMeanStdStale = defaultLocal.playerOvrMeanStdStale;
 		local.playingUntilEndOfRound = defaultLocal.playingUntilEndOfRound;
+		local.simulatingFreeAgencyDay = defaultLocal.simulatingFreeAgencyDay;
 		local.realPlayerActiveSeasons = defaultLocal.realPlayerActiveSeasons; // Since there may be different tids in different leagues
 		local.seasonLeaders = defaultLocal.seasonLeaders;
 		local.statusText = defaultLocal.statusText;

--- a/src/worker/views/newLeague.ts
+++ b/src/worker/views/newLeague.ts
@@ -85,6 +85,10 @@ export const getDefaultSettings = () => {
 			defaultGameAttributes,
 			"playersRefuseToNegotiate",
 		),
+		freeAgencySigningsPerDay: unwrapGameAttribute(
+			defaultGameAttributes,
+			"freeAgencySigningsPerDay",
+		),
 		allStarGame: unwrapGameAttribute(defaultGameAttributes, "allStarGame"),
 		allStarNum: unwrapGameAttribute(defaultGameAttributes, "allStarNum"),
 		allStarType: unwrapGameAttribute(defaultGameAttributes, "allStarType"),

--- a/src/worker/views/settings.ts
+++ b/src/worker/views/settings.ts
@@ -38,6 +38,7 @@ type Key =
 	| "sonRate"
 	| "forceRetireAge"
 	| "forceRetireSeasons"
+	| "freeAgencySigningsPerDay"
 	| "salaryCapType"
 	| "numGamesPlayoffSeries"
 	| "numPlayoffByes"
@@ -257,6 +258,7 @@ const updateSettings = async (inputs: unknown, updateEvents: UpdateEvents) => {
 			sonRate: g.get("sonRate"),
 			forceRetireAge: g.get("forceRetireAge"),
 			forceRetireSeasons: g.get("forceRetireSeasons"),
+			freeAgencySigningsPerDay: g.get("freeAgencySigningsPerDay"),
 			salaryCapType: g.get("salaryCapType"),
 			numGamesPlayoffSeries: g.get("numGamesPlayoffSeries"),
 			numPlayoffByes: g.get("numPlayoffByes"),

--- a/tools/build/generateJsonSchema.ts
+++ b/tools/build/generateJsonSchema.ts
@@ -766,6 +766,13 @@ export const generateJsonSchema = (sport: Sport | "test") => {
 						type: "integer",
 						minimum: 0,
 					},
+					freeAgencySigningsPerDay: {
+						type: "integer",
+					},
+					freeAgencySigningsThisDay: {
+						type: "integer",
+						minimum: 0,
+					},
 					defaultStadiumCapacity: {
 						type: "integer",
 						minimum: 0,


### PR DESCRIPTION
For a more realistic free agency experience, the simulation will automatically advance to the next day after a set number of players (x) have been signed. The value of 'x' can be adjusted in the settings. If 'x' is set to 0 or -1, this function will be disabled, and free agency will operate as usual.
https://github.com/zengm-games/zengm/issues/511