### PR TITLE
Add CSV import to schedule editor

### DIFF
--- a/public/css/light.scss
+++ b/public/css/light.scss
@@ -1476,7 +1476,7 @@ code {
 	transition: none !important;
 }
 
-hr {
+hr.my-hr {
 	background-color: $black;
 	opacity: 0.1;
 }

--- a/src/ui/components/Controller/Footer.tsx
+++ b/src/ui/components/Controller/Footer.tsx
@@ -109,7 +109,7 @@ export const Footer = memo(() => {
 			</div>
 
 			<div className="clearfix" />
-			<hr />
+			<hr className="my-hr" />
 
 			<div
 				className="d-flex flex-wrap justify-content-between text-body-secondary"

--- a/src/ui/views/AccountUpdateCard.tsx
+++ b/src/ui/views/AccountUpdateCard.tsx
@@ -128,7 +128,7 @@ const AccountUpdateCard = (props: View<"accountUpdateCard">) => {
 				Expiration: {expMonth}/{expYear}
 			</p>
 
-			<hr />
+			<hr className="my-hr" />
 
 			<p>To replace your saved card with a new one, fill out this form:</p>
 

--- a/src/ui/views/ManageTeams/index.tsx
+++ b/src/ui/views/ManageTeams/index.tsx
@@ -308,7 +308,7 @@ const ManageTeams = (props: View<"manageTeams">) => {
 								t={t}
 							/>
 							<div className="col-12 d-lg-none" style={{ marginTop: -12 }}>
-								<hr />
+								<hr className="my-hr" />
 							</div>
 						</Fragment>
 					))}

--- a/src/ui/views/ScheduleEditor/index.tsx
+++ b/src/ui/views/ScheduleEditor/index.tsx
@@ -1152,6 +1152,25 @@ const ScheduleEditor = ({
 								Regenerate schedule
 							</Dropdown.Item>
 							<Dropdown.Item
+								onClick={async () => {
+									const proceed = await confirm(
+										"Are you sure you want to delete the entire schedule?",
+										{
+											okText: "Clear schedule",
+										},
+									);
+									if (proceed) {
+										dispatch({
+											type: "clearSchedule",
+											maxDayAlreadyPlayed,
+										});
+									}
+								}}
+							>
+								Clear schedule
+							</Dropdown.Item>
+							<Dropdown.Divider />
+							<Dropdown.Item
 								onClick={() => {
 									exportScheduleCSV(schedule, teams);
 								}}
@@ -1172,24 +1191,6 @@ const ScheduleEditor = ({
 									onClick={resetFileInput}
 									onChange={handleFileUpload}
 								/>
-							</Dropdown.Item>
-							<Dropdown.Item
-								onClick={async () => {
-									const proceed = await confirm(
-										"Are you sure you want to delete the entire schedule?",
-										{
-											okText: "Clear schedule",
-										},
-									);
-									if (proceed) {
-										dispatch({
-											type: "clearSchedule",
-											maxDayAlreadyPlayed,
-										});
-									}
-								}}
-							>
-								Clear schedule
 							</Dropdown.Item>
 						</Dropdown.Menu>
 					</Dropdown>

--- a/src/ui/views/ScheduleEditor/index.tsx
+++ b/src/ui/views/ScheduleEditor/index.tsx
@@ -211,14 +211,12 @@ const validateAndParseScheduleCSV = (
 		const teamsOnDay = teamsByDay.getOrInsertComputed(day, () => new Set());
 
 		for (const colAbbrev of teamColumns) {
-			const cellText = row[colAbbrev]?.trim();
-			if (!cellText) {
+			const cellAbbrev = row[colAbbrev]?.trim();
+			if (!cellAbbrev) {
 				continue;
 			}
 
 			const colTeam = teamsByAbbrev[colAbbrev]!;
-			const cellIsAway = cellText.startsWith("@");
-			const cellAbbrev = cellIsAway ? cellText.slice(1) : cellText;
 
 			const cellTeam = teamsByAbbrev[cellAbbrev];
 			if (!cellTeam) {
@@ -243,8 +241,8 @@ const validateAndParseScheduleCSV = (
 
 			if (!dayGames.has(gameKey)) {
 				dayGames.set(gameKey, {
-					home: cellIsAway ? cellAbbrev : colAbbrev,
-					away: cellIsAway ? colAbbrev : cellAbbrev,
+					home: colAbbrev,
+					away: cellAbbrev,
 				});
 			}
 		}
@@ -291,12 +289,8 @@ const exportScheduleCSV = (schedule: Schedule, teams: Team[]) => {
 				row[1] = TRADE_DEADLINE_LABEL;
 			} else if (game.type === "game") {
 				const homeIdx = abbrevToIdx.get(game.homeAbbrev);
-				const awayIdx = abbrevToIdx.get(game.awayAbbrev);
 				if (homeIdx !== undefined) {
 					row[homeIdx + 1] = game.awayAbbrev;
-				}
-				if (awayIdx !== undefined) {
-					row[awayIdx + 1] = `@${game.homeAbbrev}`;
 				}
 			}
 		}

--- a/src/ui/views/ScheduleEditor/index.tsx
+++ b/src/ui/views/ScheduleEditor/index.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useReducer,
+	useRef,
+	useState,
+	type ChangeEvent,
+} from "react";
 import useTitleBar from "../../hooks/useTitleBar.tsx";
 import { helpers } from "../../util/helpers.ts";
 import { logEvent } from "../../util/logEvent.ts";
@@ -16,6 +23,9 @@ import clsx from "clsx";
 import { useBlocker } from "../../hooks/useBlocker.ts";
 import { StickyBottomButtons } from "../../components/StickyBottomButtons.tsx";
 import { confirm } from "../../util/confirm.tsx";
+import { csvParse } from "d3-dsv";
+import { resetFileInput } from "../../util/resetFileInput.ts";
+import { IMPORT_FILE_STYLE } from "../Settings/RowsEditor.tsx";
 
 type Schedule = View<"scheduleEditor">["schedule"];
 
@@ -103,6 +113,131 @@ const notifyPlaceSpecial = (
 			saveToDb: false,
 		});
 	});
+};
+
+const validateAndParseScheduleCSV = (
+	csvText: string,
+	teams: Team[],
+	maxDayAlreadyPlayed: number,
+): Schedule => {
+	const parsed = csvParse(csvText);
+
+	if (parsed.columns[0] !== "D") {
+		throw new Error('First column must be "D" for day number');
+	}
+
+	const teamsByAbbrev = groupByUnique(teams, (t) => t.seasonAttrs.abbrev);
+
+	const teamColumns = parsed.columns.slice(1);
+	for (const abbrev of teamColumns) {
+		if (!teamsByAbbrev[abbrev]) {
+			throw new Error(
+				`Unknown team abbreviation in header: "${abbrev}". Available teams: ${teams.map((t) => t.seasonAttrs.abbrev).join(", ")}`,
+			);
+		}
+	}
+
+	const gamesByDay = new Map<
+		number,
+		Map<string, { home: string; away: string }>
+	>();
+	const teamsByDay = new Map<number, Set<number>>();
+
+	for (const row of parsed) {
+		const dayStr = row.D;
+		if (!dayStr) {
+			continue;
+		}
+
+		const day = Number.parseInt(dayStr);
+		if (Number.isNaN(day)) {
+			throw new Error(`Invalid day "${dayStr}". Must be a number.`);
+		}
+		if (day <= maxDayAlreadyPlayed) {
+			throw new Error(
+				`Day ${day} has already been played. Cannot upload schedules for days <= ${maxDayAlreadyPlayed}.`,
+			);
+		}
+
+		if (!gamesByDay.has(day)) {
+			gamesByDay.set(day, new Map());
+		}
+		if (!teamsByDay.has(day)) {
+			teamsByDay.set(day, new Set());
+		}
+
+		const dayGames = gamesByDay.get(day)!;
+		const teamsOnDay = teamsByDay.get(day)!;
+
+		for (const homeAbbrev of teamColumns) {
+			const cell = row[homeAbbrev]?.trim();
+			if (!cell) {
+				continue;
+			}
+
+			const homeTeam = teamsByAbbrev[homeAbbrev]!;
+			const isAway = cell.startsWith("@");
+			const opponentAbbrev = isAway ? cell.slice(1) : cell;
+
+			const opponentTeam = teamsByAbbrev[opponentAbbrev];
+			if (!opponentTeam) {
+				throw new Error(
+					`Unknown opponent "${opponentAbbrev}" for ${homeAbbrev} on day ${day}`,
+				);
+			}
+			if (homeTeam.tid === opponentTeam.tid) {
+				throw new Error(`Team ${homeAbbrev} cannot play itself on day ${day}`);
+			}
+			if (teamsOnDay.has(homeTeam.tid)) {
+				throw new Error(`Team ${homeAbbrev} has multiple games on day ${day}`);
+			}
+
+			teamsOnDay.add(homeTeam.tid);
+
+			const [tid1, tid2] =
+				homeTeam.tid < opponentTeam.tid
+					? [homeTeam.tid, opponentTeam.tid]
+					: [opponentTeam.tid, homeTeam.tid];
+			const gameKey = `${tid1}-${tid2}`;
+
+			const existingGame = dayGames.get(gameKey);
+			if (existingGame) {
+				if (
+					(isAway &&
+						(existingGame.away !== homeAbbrev ||
+							existingGame.home !== opponentAbbrev)) ||
+					(!isAway &&
+						(existingGame.home !== homeAbbrev ||
+							existingGame.away !== opponentAbbrev))
+				) {
+					throw new Error(
+						`Inconsistent game on day ${day}: ${homeAbbrev} shows ${isAway ? "@" : ""}${opponentAbbrev} but the matchup is recorded as ${existingGame.home} vs ${existingGame.away}`,
+					);
+				}
+			} else {
+				dayGames.set(gameKey, {
+					home: isAway ? opponentAbbrev : homeAbbrev,
+					away: isAway ? homeAbbrev : opponentAbbrev,
+				});
+			}
+		}
+	}
+
+	const newSchedule: Schedule = [];
+	for (const [day, dayGames] of gamesByDay) {
+		for (const game of dayGames.values()) {
+			newSchedule.push({
+				type: "game",
+				day,
+				awayTid: teamsByAbbrev[game.away]!.tid,
+				awayAbbrev: teamsByAbbrev[game.away]!.seasonAttrs.abbrev,
+				homeTid: teamsByAbbrev[game.home]!.tid,
+				homeAbbrev: teamsByAbbrev[game.home]!.seasonAttrs.abbrev,
+			});
+		}
+	}
+
+	return orderBy(newSchedule, ["day"]);
 };
 
 const reducer = (
@@ -427,6 +562,56 @@ const ScheduleEditor = ({
 	const [showRegenerateScheduleModal, setShowRegenerateScheduleModal] =
 		useState(false);
 	const [regenerated, setRegenerated] = useState(false);
+	const [uploadError, setUploadError] = useState<string | undefined>();
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const handleFileUpload = useCallback(
+		(event: ChangeEvent<HTMLInputElement>) => {
+			const file = event.target.files?.[0];
+			if (!file) {
+				return;
+			}
+
+			setUploadError(undefined);
+
+			const reader = new FileReader();
+			reader.readAsText(file);
+
+			reader.onload = (e) => {
+				try {
+					const csvText = e.target?.result as string;
+					const uploaded = validateAndParseScheduleCSV(
+						csvText,
+						teams,
+						maxDayAlreadyPlayed,
+					);
+					const completed = schedule.filter((g) => g.type === "completed");
+					dispatch({
+						type: "resetSchedule",
+						schedule: [...completed, ...uploaded],
+						dirty: true,
+					});
+					logEvent({
+						type: "success",
+						text: `Successfully imported ${uploaded.length} games from CSV`,
+						saveToDb: false,
+					});
+				} catch (error) {
+					setUploadError(error.message);
+					logEvent({
+						type: "error",
+						text: `Error importing schedule: ${error.message}`,
+						saveToDb: false,
+					});
+				}
+			};
+
+			reader.onerror = () => {
+				setUploadError("Failed to read file");
+			};
+		},
+		[dispatch, maxDayAlreadyPlayed, schedule, teams],
+	);
 
 	if (phase !== PHASE.REGULAR_SEASON && phase !== PHASE.AFTER_TRADE_DEADLINE) {
 		return <p>You can only edit the schedule during the regular season.</p>;
@@ -747,6 +932,11 @@ const ScheduleEditor = ({
 				Home games are shown in normal text and away games are shown in{" "}
 				<span className="text-body-secondary">faded text</span>.
 			</p>
+			{uploadError ? (
+				<div className="alert alert-danger">
+					<strong>Error importing schedule:</strong> {uploadError}
+				</div>
+			) : null}
 			{!godMode ? (
 				<div>
 					<span className="alert alert-warning d-inline-block mb-0">
@@ -916,6 +1106,21 @@ const ScheduleEditor = ({
 								}}
 							>
 								Regenerate schedule
+							</Dropdown.Item>
+							<Dropdown.Item
+								as="div"
+								style={{ position: "relative", overflow: "hidden" }}
+							>
+								Import schedule from CSV
+								<input
+									ref={fileInputRef}
+									className="cursor-pointer"
+									type="file"
+									accept=".csv"
+									style={IMPORT_FILE_STYLE}
+									onClick={resetFileInput}
+									onChange={handleFileUpload}
+								/>
 							</Dropdown.Item>
 							<Dropdown.Item
 								onClick={async () => {

--- a/src/ui/views/ScheduleEditor/index.tsx
+++ b/src/ui/views/ScheduleEditor/index.tsx
@@ -160,10 +160,7 @@ const validateAndParseScheduleCSV = (
 		throw new Error(`Duplicate abbrevs in header: ${array.join(", ")}`);
 	}
 
-	const gamesByDay = new Map<
-		number,
-		Map<string, { home: string; away: string }>
-	>();
+	const gamesByDay = new Map<number, { away: Team; home: Team }[]>();
 	const teamsByDay = new Map<number, Set<number>>();
 	const specials: Extract<
 		Schedule[number],
@@ -207,7 +204,7 @@ const validateAndParseScheduleCSV = (
 			continue;
 		}
 
-		const dayGames = gamesByDay.getOrInsertComputed(day, () => new Map());
+		const dayGames = gamesByDay.getOrInsertComputed(day, () => []);
 		const teamsOnDay = teamsByDay.getOrInsertComputed(day, () => new Set());
 
 		for (const colAbbrev of teamColumns) {
@@ -233,31 +230,23 @@ const validateAndParseScheduleCSV = (
 
 			teamsOnDay.add(cellTeam.tid);
 
-			const [tid1, tid2] =
-				colTeam.tid < cellTeam.tid
-					? [colTeam.tid, cellTeam.tid]
-					: [cellTeam.tid, colTeam.tid];
-			const gameKey = `${tid1}-${tid2}`;
-
-			if (!dayGames.has(gameKey)) {
-				dayGames.set(gameKey, {
-					home: colAbbrev,
-					away: cellAbbrev,
-				});
-			}
+			dayGames.push({
+				away: cellTeam,
+				home: colTeam,
+			});
 		}
 	}
 
 	const newSchedule: Schedule = [...specials];
 	for (const [day, dayGames] of gamesByDay) {
-		for (const game of dayGames.values()) {
+		for (const { away, home } of dayGames.values()) {
 			newSchedule.push({
 				type: "game",
 				day,
-				awayTid: teamsByAbbrev[game.away]!.tid,
-				awayAbbrev: teamsByAbbrev[game.away]!.seasonAttrs.abbrev,
-				homeTid: teamsByAbbrev[game.home]!.tid,
-				homeAbbrev: teamsByAbbrev[game.home]!.seasonAttrs.abbrev,
+				awayTid: away.tid,
+				awayAbbrev: away.seasonAttrs.abbrev,
+				homeTid: home.tid,
+				homeAbbrev: home.seasonAttrs.abbrev,
 			});
 		}
 	}
@@ -278,7 +267,7 @@ const exportScheduleCSV = (schedule: Schedule, teams: Team[]) => {
 		dayMap.getOrInsertComputed(game.day, () => []).push(game);
 	}
 
-	const rows: string[][] = [["D", ...abbrevs]];
+	const rows: string[][] = [["Day", ...abbrevs]];
 	for (const day of orderBy([...dayMap.keys()], (d) => d)) {
 		const row = Array<string>(abbrevs.length + 1).fill("");
 		row[0] = String(day);
@@ -656,7 +645,7 @@ const ScheduleEditor = ({
 				} catch (error) {
 					logEvent({
 						type: "error",
-						text: `Error importing schedule: ${error.message}`,
+						text: error.message,
 						saveToDb: false,
 					});
 				}

--- a/src/ui/views/ScheduleEditor/index.tsx
+++ b/src/ui/views/ScheduleEditor/index.tsx
@@ -23,7 +23,8 @@ import clsx from "clsx";
 import { useBlocker } from "../../hooks/useBlocker.ts";
 import { StickyBottomButtons } from "../../components/StickyBottomButtons.tsx";
 import { confirm } from "../../util/confirm.tsx";
-import { csvParse } from "d3-dsv";
+import { csvFormatRows, csvParse } from "d3-dsv";
+import { downloadFile } from "../../util/downloadFile.ts";
 import { resetFileInput } from "../../util/resetFileInput.ts";
 import { IMPORT_FILE_STYLE } from "../Settings/RowsEditor.tsx";
 
@@ -40,6 +41,9 @@ type ScheduleDay = {
 };
 
 type Team = View<"scheduleEditor">["teams"][number];
+
+const ALL_STAR_GAME_LABEL = "All-Star Game";
+const TRADE_DEADLINE_LABEL = "Trade Deadline";
 
 const deleteSpecial = (
 	schedule: Schedule,
@@ -109,7 +113,7 @@ const notifyPlaceSpecial = (
 	setTimeout(() => {
 		logEvent({
 			type: "info",
-			text: `Placed the ${type === "allStarGame" ? "All-Star Game" : "trade deadline"} on day ${day}`,
+			text: `Placed the ${type === "allStarGame" ? ALL_STAR_GAME_LABEL : TRADE_DEADLINE_LABEL} on day ${day}`,
 			saveToDb: false,
 		});
 	});
@@ -121,10 +125,6 @@ const validateAndParseScheduleCSV = (
 	maxDayAlreadyPlayed: number,
 ): Schedule => {
 	const parsed = csvParse(csvText);
-
-	if (parsed.columns[0] !== "D") {
-		throw new Error('First column must be "D" for day number');
-	}
 
 	const teamsByAbbrev = groupByUnique(teams, (t) => t.seasonAttrs.abbrev);
 
@@ -142,9 +142,10 @@ const validateAndParseScheduleCSV = (
 		Map<string, { home: string; away: string }>
 	>();
 	const teamsByDay = new Map<number, Set<number>>();
+	const specials: Schedule[number][] = [];
 
 	for (const row of parsed) {
-		const dayStr = row.D;
+		const dayStr = row[parsed.columns[0]!];
 		if (!dayStr) {
 			continue;
 		}
@@ -159,15 +160,26 @@ const validateAndParseScheduleCSV = (
 			);
 		}
 
-		if (!gamesByDay.has(day)) {
-			gamesByDay.set(day, new Map());
-		}
-		if (!teamsByDay.has(day)) {
-			teamsByDay.set(day, new Set());
+		const firstCell = row[teamColumns[0]!]?.trim();
+		if (
+			firstCell === ALL_STAR_GAME_LABEL ||
+			firstCell === TRADE_DEADLINE_LABEL
+		) {
+			for (const abbrev of teamColumns.slice(1)) {
+				if (row[abbrev]?.trim()) {
+					throw new Error(`${firstCell} must be the only entry on day ${day}`);
+				}
+			}
+			specials.push(
+				firstCell === ALL_STAR_GAME_LABEL
+					? { type: "allStarGame", day, homeTid: -1, awayTid: -2 }
+					: { type: "tradeDeadline", day, homeTid: -3, awayTid: -3 },
+			);
+			continue;
 		}
 
-		const dayGames = gamesByDay.get(day)!;
-		const teamsOnDay = teamsByDay.get(day)!;
+		const dayGames = gamesByDay.getOrInsertComputed(day, () => new Map());
+		const teamsOnDay = teamsByDay.getOrInsertComputed(day, () => new Set());
 
 		for (const homeAbbrev of teamColumns) {
 			const cell = row[homeAbbrev]?.trim();
@@ -200,21 +212,7 @@ const validateAndParseScheduleCSV = (
 					: [opponentTeam.tid, homeTeam.tid];
 			const gameKey = `${tid1}-${tid2}`;
 
-			const existingGame = dayGames.get(gameKey);
-			if (existingGame) {
-				if (
-					(isAway &&
-						(existingGame.away !== homeAbbrev ||
-							existingGame.home !== opponentAbbrev)) ||
-					(!isAway &&
-						(existingGame.home !== homeAbbrev ||
-							existingGame.away !== opponentAbbrev))
-				) {
-					throw new Error(
-						`Inconsistent game on day ${day}: ${homeAbbrev} shows ${isAway ? "@" : ""}${opponentAbbrev} but the matchup is recorded as ${existingGame.home} vs ${existingGame.away}`,
-					);
-				}
-			} else {
+			if (!dayGames.has(gameKey)) {
 				dayGames.set(gameKey, {
 					home: isAway ? opponentAbbrev : homeAbbrev,
 					away: isAway ? homeAbbrev : opponentAbbrev,
@@ -223,7 +221,7 @@ const validateAndParseScheduleCSV = (
 		}
 	}
 
-	const newSchedule: Schedule = [];
+	const newSchedule: Schedule = [...specials];
 	for (const [day, dayGames] of gamesByDay) {
 		for (const game of dayGames.values()) {
 			newSchedule.push({
@@ -238,6 +236,45 @@ const validateAndParseScheduleCSV = (
 	}
 
 	return orderBy(newSchedule, ["day"]);
+};
+
+const exportScheduleCSV = (schedule: Schedule, teams: Team[]) => {
+	const sortedTeams = orderBy(teams, (t) => t.seasonAttrs.abbrev);
+	const abbrevs = sortedTeams.map((t) => t.seasonAttrs.abbrev);
+	const abbrevToIdx = new Map(abbrevs.map((a, i) => [a, i]));
+
+	const dayMap = new Map<number, Schedule[number][]>();
+	for (const game of schedule) {
+		if (game.type === "completed" || game.type === "placeholder") {
+			continue;
+		}
+		dayMap.getOrInsertComputed(game.day, () => []).push(game);
+	}
+
+	const rows: string[][] = [["D", ...abbrevs]];
+	for (const day of orderBy([...dayMap.keys()], (d) => d)) {
+		const row = Array<string>(abbrevs.length + 1).fill("");
+		row[0] = String(day);
+		for (const game of dayMap.get(day)!) {
+			if (game.type === "allStarGame") {
+				row[1] = ALL_STAR_GAME_LABEL;
+			} else if (game.type === "tradeDeadline") {
+				row[1] = TRADE_DEADLINE_LABEL;
+			} else if (game.type === "game") {
+				const homeIdx = abbrevToIdx.get(game.homeAbbrev);
+				const awayIdx = abbrevToIdx.get(game.awayAbbrev);
+				if (homeIdx !== undefined) {
+					row[homeIdx + 1] = game.awayAbbrev;
+				}
+				if (awayIdx !== undefined) {
+					row[awayIdx + 1] = `@${game.homeAbbrev}`;
+				}
+			}
+		}
+		rows.push(row);
+	}
+
+	downloadFile("schedule.csv", csvFormatRows(rows), "text/csv");
 };
 
 const reducer = (
@@ -562,7 +599,6 @@ const ScheduleEditor = ({
 	const [showRegenerateScheduleModal, setShowRegenerateScheduleModal] =
 		useState(false);
 	const [regenerated, setRegenerated] = useState(false);
-	const [uploadError, setUploadError] = useState<string | undefined>();
 	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	const handleFileUpload = useCallback(
@@ -571,8 +607,6 @@ const ScheduleEditor = ({
 			if (!file) {
 				return;
 			}
-
-			setUploadError(undefined);
 
 			const reader = new FileReader();
 			reader.readAsText(file);
@@ -597,7 +631,6 @@ const ScheduleEditor = ({
 						saveToDb: false,
 					});
 				} catch (error) {
-					setUploadError(error.message);
 					logEvent({
 						type: "error",
 						text: `Error importing schedule: ${error.message}`,
@@ -607,7 +640,11 @@ const ScheduleEditor = ({
 			};
 
 			reader.onerror = () => {
-				setUploadError("Failed to read file");
+				logEvent({
+					type: "error",
+					text: "Failed to read CSV file",
+					saveToDb: false,
+				});
 			};
 		},
 		[dispatch, maxDayAlreadyPlayed, schedule, teams],
@@ -773,8 +810,8 @@ const ScheduleEditor = ({
 							{
 								value:
 									row.special === "allStarGame"
-										? "All-Star Game"
-										: "Trade Deadline",
+										? ALL_STAR_GAME_LABEL
+										: TRADE_DEADLINE_LABEL,
 								classNames: "text-start",
 								colSpanToEnd: true,
 							},
@@ -932,11 +969,6 @@ const ScheduleEditor = ({
 				Home games are shown in normal text and away games are shown in{" "}
 				<span className="text-body-secondary">faded text</span>.
 			</p>
-			{uploadError ? (
-				<div className="alert alert-danger">
-					<strong>Error importing schedule:</strong> {uploadError}
-				</div>
-			) : null}
 			{!godMode ? (
 				<div>
 					<span className="alert alert-warning d-inline-block mb-0">
@@ -1106,6 +1138,13 @@ const ScheduleEditor = ({
 								}}
 							>
 								Regenerate schedule
+							</Dropdown.Item>
+							<Dropdown.Item
+								onClick={() => {
+									exportScheduleCSV(schedule, teams);
+								}}
+							>
+								Export schedule to CSV
 							</Dropdown.Item>
 							<Dropdown.Item
 								as="div"

--- a/src/ui/views/ScheduleEditor/index.tsx
+++ b/src/ui/views/ScheduleEditor/index.tsx
@@ -1,11 +1,4 @@
-import {
-	useCallback,
-	useEffect,
-	useReducer,
-	useRef,
-	useState,
-	type ChangeEvent,
-} from "react";
+import { useCallback, useEffect, useReducer, useRef, useState, type ChangeEvent,} from "react";
 import useTitleBar from "../../hooks/useTitleBar.tsx";
 import { helpers } from "../../util/helpers.ts";
 import { logEvent } from "../../util/logEvent.ts";

--- a/src/ui/views/ScheduleEditor/index.tsx
+++ b/src/ui/views/ScheduleEditor/index.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useReducer, useRef, useState, type ChangeEvent,} from "react";
+import {
+	useCallback,
+	useEffect,
+	useReducer,
+	useRef,
+	useState,
+	type ChangeEvent,
+} from "react";
 import useTitleBar from "../../hooks/useTitleBar.tsx";
 import { helpers } from "../../util/helpers.ts";
 import { logEvent } from "../../util/logEvent.ts";
@@ -112,6 +119,21 @@ const notifyPlaceSpecial = (
 	});
 };
 
+const findDuplicates = (strings: string[]) => {
+	const seen = new Set<string>();
+	const duplicates = new Set<string>();
+
+	for (const string of strings) {
+		if (seen.has(string)) {
+			duplicates.add(string);
+		} else {
+			seen.add(string);
+		}
+	}
+
+	return duplicates;
+};
+
 const validateAndParseScheduleCSV = (
 	csvText: string,
 	teams: Team[],
@@ -121,7 +143,10 @@ const validateAndParseScheduleCSV = (
 
 	const teamsByAbbrev = groupByUnique(teams, (t) => t.seasonAttrs.abbrev);
 
-	const teamColumns = parsed.columns.slice(1);
+	const teamColumns = parsed.columns.slice(1).map((abbrev) => abbrev.trim());
+	if (!teamColumns[0]) {
+		throw new Error("No team columns found");
+	}
 	for (const abbrev of teamColumns) {
 		if (!teamsByAbbrev[abbrev]) {
 			throw new Error(
@@ -129,16 +154,27 @@ const validateAndParseScheduleCSV = (
 			);
 		}
 	}
+	const duplicateAbbrevs = findDuplicates(teamColumns);
+	if (duplicateAbbrevs.size > 0) {
+		const array = Array.from(duplicateAbbrevs);
+		throw new Error(`Duplicate abbrevs in header: ${array.join(", ")}`);
+	}
 
 	const gamesByDay = new Map<
 		number,
 		Map<string, { home: string; away: string }>
 	>();
 	const teamsByDay = new Map<number, Set<number>>();
-	const specials: Schedule[number][] = [];
+	const specials: Extract<
+		Schedule[number],
+		{ type: "allStarGame" | "tradeDeadline" }
+	>[] = [];
 
 	for (const row of parsed) {
-		const dayStr = row[parsed.columns[0]!];
+		if (!parsed.columns[0]) {
+			continue;
+		}
+		const dayStr = row[parsed.columns[0]];
 		if (!dayStr) {
 			continue;
 		}
@@ -153,7 +189,7 @@ const validateAndParseScheduleCSV = (
 			);
 		}
 
-		const firstCell = row[teamColumns[0]!]?.trim();
+		const firstCell = row[teamColumns[0]]?.trim();
 		if (
 			firstCell === ALL_STAR_GAME_LABEL ||
 			firstCell === TRADE_DEADLINE_LABEL
@@ -174,41 +210,41 @@ const validateAndParseScheduleCSV = (
 		const dayGames = gamesByDay.getOrInsertComputed(day, () => new Map());
 		const teamsOnDay = teamsByDay.getOrInsertComputed(day, () => new Set());
 
-		for (const homeAbbrev of teamColumns) {
-			const cell = row[homeAbbrev]?.trim();
-			if (!cell) {
+		for (const colAbbrev of teamColumns) {
+			const cellText = row[colAbbrev]?.trim();
+			if (!cellText) {
 				continue;
 			}
 
-			const homeTeam = teamsByAbbrev[homeAbbrev]!;
-			const isAway = cell.startsWith("@");
-			const opponentAbbrev = isAway ? cell.slice(1) : cell;
+			const colTeam = teamsByAbbrev[colAbbrev]!;
+			const cellIsAway = cellText.startsWith("@");
+			const cellAbbrev = cellIsAway ? cellText.slice(1) : cellText;
 
-			const opponentTeam = teamsByAbbrev[opponentAbbrev];
-			if (!opponentTeam) {
+			const cellTeam = teamsByAbbrev[cellAbbrev];
+			if (!cellTeam) {
 				throw new Error(
-					`Unknown opponent "${opponentAbbrev}" for ${homeAbbrev} on day ${day}`,
+					`Unknown opponent "${cellAbbrev}" for ${colAbbrev} on day ${day}`,
 				);
 			}
-			if (homeTeam.tid === opponentTeam.tid) {
-				throw new Error(`Team ${homeAbbrev} cannot play itself on day ${day}`);
+			if (colTeam.tid === cellTeam.tid) {
+				throw new Error(`${colAbbrev} cannot play itself on day ${day}`);
 			}
-			if (teamsOnDay.has(homeTeam.tid)) {
-				throw new Error(`Team ${homeAbbrev} has multiple games on day ${day}`);
+			if (teamsOnDay.has(cellTeam.tid)) {
+				throw new Error(`${cellAbbrev} has multiple games on day ${day}`);
 			}
 
-			teamsOnDay.add(homeTeam.tid);
+			teamsOnDay.add(cellTeam.tid);
 
 			const [tid1, tid2] =
-				homeTeam.tid < opponentTeam.tid
-					? [homeTeam.tid, opponentTeam.tid]
-					: [opponentTeam.tid, homeTeam.tid];
+				colTeam.tid < cellTeam.tid
+					? [colTeam.tid, cellTeam.tid]
+					: [cellTeam.tid, colTeam.tid];
 			const gameKey = `${tid1}-${tid2}`;
 
 			if (!dayGames.has(gameKey)) {
 				dayGames.set(gameKey, {
-					home: isAway ? opponentAbbrev : homeAbbrev,
-					away: isAway ? homeAbbrev : opponentAbbrev,
+					home: cellIsAway ? cellAbbrev : colAbbrev,
+					away: cellIsAway ? colAbbrev : cellAbbrev,
 				});
 			}
 		}

--- a/src/ui/views/ScheduleEditor/index.tsx
+++ b/src/ui/views/ScheduleEditor/index.tsx
@@ -42,6 +42,7 @@ type ScheduleDay = {
 
 type Team = View<"scheduleEditor">["teams"][number];
 
+// If these are ever changed it will break any previous CSV schedules on import, so be careful!
 const ALL_STAR_GAME_LABEL = "All-Star Game";
 const TRADE_DEADLINE_LABEL = "Trade Deadline";
 


### PR DESCRIPTION
## Summary

Adds an **Import schedule from CSV** option to the schedule editor's Actions dropdown, allowing users to replace the upcoming schedule by uploading a CSV file.

**CSV format:**
- First column `D` — the game day number
- Remaining column headers — team abbreviations (e.g. `BOS`, `LAL`)
- Each cell: opponent abbreviation for a home game, or `@ABBREV` for an away game
- Each matchup appears once per team (both perspectives must agree on home/away)

**Example:**
```
D,BOS,LAL,CHI,MIA
1,LAL,@BOS,,
1,,,MIA,@CHI
```

**Checks:**
- First column not named `D`
- Unknown team abbreviations in headers or cells
- Day values that have already been played
- A team appearing in more than one game on the same day
- Conflicting home/away designations between a team's two CSV entries for the same matchup

Generated the summary with the help of Claude Code.