### PR TITLE
Fix stuck draft when changing draft type during draft lottery phase

### DIFF
--- a/src/worker/core/draft/deleteLotteryResultIfNoDraftYet.test.ts
+++ b/src/worker/core/draft/deleteLotteryResultIfNoDraftYet.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, assert, test } from "vitest";
+import { PHASE } from "../../../common/constants.ts";
+import type { DraftLotteryResult, Phase } from "../../../common/types.ts";
+import { mockIDBLeague } from "../../../test/helpers.ts";
+import { idb } from "../../db/index.ts";
+import { g } from "../../util/index.ts";
+import setGameAttributes from "../league/setGameAttributes.ts";
+import { draft } from "../index.ts";
+import { loadTeamSeasons } from "./testHelpers.ts";
+
+const addStaleDraftLotteryResult = async () => {
+	const draftLotteryResult: DraftLotteryResult = {
+		season: g.get("season"),
+		draftType: "nba1994",
+		result: [
+			{
+				tid: 0,
+				originalTid: 0,
+				chances: 140,
+				pick: 1,
+				dpid: 0,
+			},
+		],
+	};
+
+	await idb.cache.draftLotteryResults.put(draftLotteryResult);
+};
+
+const setup = async (phase: Phase) => {
+	idb.league = mockIDBLeague();
+	await loadTeamSeasons();
+	g.setWithoutSavingToDB("phase", phase);
+	g.setWithoutSavingToDB("draftType", "nba1994");
+	await addStaleDraftLotteryResult();
+};
+
+afterEach(() => {
+	// @ts-expect-error
+	idb.league = undefined;
+});
+
+test("changing draft type during draft lottery deletes stale lottery result and generates order", async () => {
+	await setup(PHASE.DRAFT_LOTTERY);
+
+	const draftPicksBefore = await draft.getOrder();
+	assert.strictEqual(draftPicksBefore.length, 60);
+	assert(draftPicksBefore.every((dp) => dp.pick === 0));
+
+	await setGameAttributes({
+		draftType: "random",
+	});
+
+	const draftLotteryResult = await idb.getCopy.draftLotteryResults(
+		{
+			season: g.get("season"),
+		},
+		"noCopyCache",
+	);
+	assert.strictEqual(draftLotteryResult, undefined);
+
+	const draftPicksAfter = await draft.getOrder();
+	assert.strictEqual(draftPicksAfter.length, 60);
+	assert(draftPicksAfter.every((dp) => dp.pick > 0));
+	assert.strictEqual(g.get("numDraftPicksCurrent"), 60);
+});
+
+test("changing draft type before draft lottery does not delete lottery result or generate order", async () => {
+	await setup(PHASE.PLAYOFFS);
+
+	await setGameAttributes({
+		draftType: "random",
+	});
+
+	const draftLotteryResult = await idb.getCopy.draftLotteryResults(
+		{
+			season: g.get("season"),
+		},
+		"noCopyCache",
+	);
+	assert(draftLotteryResult);
+	assert.strictEqual(draftLotteryResult.draftType, "nba1994");
+
+	const draftPicks = await draft.getOrder();
+	assert.strictEqual(draftPicks.length, 60);
+	assert(draftPicks.every((dp) => dp.pick === 0));
+});

--- a/src/worker/core/draft/deleteLotteryResultIfNoDraftYet.ts
+++ b/src/worker/core/draft/deleteLotteryResultIfNoDraftYet.ts
@@ -2,7 +2,7 @@ import { PHASE } from "../../../common/constants.ts";
 import { idb } from "../../db/index.ts";
 import { g } from "../../util/index.ts";
 
-// Call this when adding/removing/enabling/disabling teams. Because if that happens during the draft lottery phase, it's possible the stored draftLotteryResult will be based on the incorrect set of teams, and it needs to be deleted so it can re-run.
+// Call this when changing anything that can invalidate the current draftLotteryResult during the draft lottery phase, such as adding/removing/enabling/disabling teams or changing draft type.
 const deleteLotteryResultIfNoDraftYet = async () => {
 	if (g.get("phase") === PHASE.DRAFT_LOTTERY) {
 		const draftLotteryResult = await idb.getCopy.draftLotteryResults(

--- a/src/worker/core/league/setGameAttributes.ts
+++ b/src/worker/core/league/setGameAttributes.ts
@@ -15,6 +15,7 @@ import { defaultTragicDeaths } from "../../util/defaultTragicDeaths.ts";
 import { defaultInjuries } from "../../util/defaultInjuries.ts";
 import { initUILocalGames } from "../../util/initUILocalGames.ts";
 import { disableNba2027, initializeNba2027 } from "../draft/nba2027.ts";
+import { NO_LOTTERY_DRAFT_TYPES, PHASE } from "../../../common/constants.ts";
 
 const updateMetaDifficulty = async (difficulty: number) => {
 	await updateMeta({
@@ -177,6 +178,14 @@ const setGameAttributes = async (
 		} else {
 			await disableCola();
 			await disableNba2027();
+		}
+
+		if (g.get("phase") === PHASE.DRAFT_LOTTERY) {
+			await draft.deleteLotteryResultIfNoDraftYet();
+
+			if (NO_LOTTERY_DRAFT_TYPES.has(updatedGameAttributes.draftType)) {
+				await draft.genOrder(false);
+			}
 		}
 	}
 

--- a/src/worker/views/draftLottery.ts
+++ b/src/worker/views/draftLottery.ts
@@ -298,7 +298,7 @@ const updateDraftLottery = async (
 
 		const draftType = draftLotteryResult
 			? draftLotteryResult.draftType
-			: "noLottery";
+			: g.get("draftType");
 
 		if (draftPicks) {
 			draftPicks = filterDraftPicks(draftPicks, draftLotteryResult);


### PR DESCRIPTION
## Summary
Changing the Draft Type setting during the draft lottery phase no longer leaves the league in an inconsistent state. The stale lottery result is invalidated and the draft order regenerates when switching to a no-lottery type, and the Draft Lottery page shows the correct type instead of always falling back to "No lottery".

## Why this matters
> "I then changed it to no lottery... the only way I can continue in the game was to start the lottery... I'm now stuck in the draft. I can't sim any picks."

That's the reporter on #491, and you reproduced it with Draft Type "Random, lottery only" -> "Random" -> "No lottery, worst to best" during the lottery phase. Two causes:

- `setGameAttributes` handled `draftType` changes only for cola/nba2027 setup. It never invalidated a stale `draftLotteryResult` or generated the draft order when the type changed mid-phase, even though `newPhaseBeforeDraft` only runs `genOrder` at phase entry for no-lottery types. Switching mid-phase landed the league in a state neither flow sets up.
- The `draftLottery` view fell back to the literal `"noLottery"` for every type that produces no lottery result, which is why "random" displayed as "No lottery" in your repro.

The fix calls the existing `deleteLotteryResultIfNoDraftYet()` (already used by the team add/remove/disable paths) when `draftType` changes during the lottery phase, runs `genOrder(false)` when the new type is in `NO_LOTTERY_DRAFT_TYPES`, and changes the current-season view fallback to `g.get("draftType")`. The past-season fallback is unchanged.

## Demo
Screenshots:

After switching to "Random" mid-phase, the page shows the right type:

![random type shown correctly](https://i.imgur.com/49jG1FV.png)

After continuing to "No lottery, worst to best", the draft proceeds normally:

![draft proceeding after type changes](https://i.imgur.com/BxmxFnW.png)

## Testing
Followed the 5-step repro from #491 in the browser: random players league with God Mode, Draft Type "Random, lottery only", sim to the draft lottery, switch to "Random", then to "No lottery, worst to best", then sim the draft. No stuck state, picks sim normally, and the lottery page label is correct at each step. `pnpm lint` and `pnpm test` pass.

Fixes #491
