### PR TITLE
Add Revenge 2 achievement and track teams that fired you

### DIFF
--- a/src/common/defaultGameAttributes.ts
+++ b/src/common/defaultGameAttributes.ts
@@ -22,6 +22,7 @@ export const wrapFromStart = <T>(value: T): GameAttributeWithHistory<T> => [
 export const gameAttributesKeysGameState: GameAttributeKey[] = [
 	"phase",
 	"nextPhase",
+	"firedTids",
 	"gameOver",
 	"godMode",
 	"godModeInPast",
@@ -159,6 +160,7 @@ export const defaultGameAttributes: GameAttributesLeagueWithHistory = {
 	injuries: undefined,
 	tragicDeaths: undefined,
 	daysLeft: 0, // Used only for free agency
+	firedTids: [],
 	gameOver: false,
 	godMode: false,
 	godModeInPast: false,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -585,6 +585,10 @@ export type GameAttributesLeague = {
 	foulsNeededToFoulOut: number;
 	foulsUntilBonus: [number, number, number];
 	foulRateFactor: number;
+	firedTids: {
+		tid: number;
+		season: number;
+	}[];
 	gameOver: boolean;
 	gender: "female" | "male";
 	goatFormula?: string;

--- a/src/worker/core/phase/genMessage.test.ts
+++ b/src/worker/core/phase/genMessage.test.ts
@@ -77,3 +77,48 @@ test("when at max for one component, message falls in between what you'd expect 
 	assert(message.text.includes("This year: Good."));
 	assert(message.text.includes("Overall: Bad."));
 });
+
+test("being fired records the user's team and season", async () => {
+	const previousFiredTids = [
+		{
+			tid: g.get("userTid") + 1,
+			season: g.get("season") - 1,
+		},
+	];
+	g.setWithoutSavingToDB("firedTids", previousFiredTids);
+
+	const teamSeasons = await idb.cache.teamSeasons.getAll();
+	assert.strictEqual(teamSeasons.length, 1);
+	teamSeasons[0]!.ownerMood = {
+		money: -1,
+		playoffs: 0,
+		wins: 0,
+	};
+
+	await genMessage(
+		{
+			money: 0,
+			playoffs: 0,
+			wins: 0,
+		},
+		{
+			money: 0,
+			playoffs: 0,
+			wins: 0,
+		},
+	);
+
+	const expectedFiredTids = [
+		...previousFiredTids,
+		{
+			tid: g.get("userTid"),
+			season: g.get("season"),
+		},
+	];
+
+	assert.deepStrictEqual(g.get("firedTids"), expectedFiredTids);
+
+	const gameAttributes = await idb.cache.gameAttributes.getAll();
+	const firedTids = gameAttributes.find((row) => row.key === "firedTids");
+	assert.deepStrictEqual(firedTids?.value, expectedFiredTids);
+});

--- a/src/worker/core/phase/genMessage.ts
+++ b/src/worker/core/phase/genMessage.ts
@@ -205,6 +205,13 @@ export const genMessage = async (
 			["new_team"],
 		)}">Take a look.</a> Please, go run one of those teams into the ground.</p>`;
 		await league.setGameAttributes({
+			firedTids: [
+				...g.get("firedTids"),
+				{
+					tid: g.get("userTid"),
+					season: g.get("season"),
+				},
+			],
 			gameOver: true,
 		});
 	}

--- a/src/worker/util/achievements.test.ts
+++ b/src/worker/util/achievements.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, assert, beforeAll, describe, test } from "vitest";
+import { afterAll, assert, beforeAll, beforeEach, describe, test } from "vitest";
 import { mockIDBLeague, resetCache, resetG } from "../../test/helpers.ts";
 import { player, team } from "../core/index.ts";
 import { idb } from "../db/index.ts";
@@ -739,5 +739,90 @@ describe("checkAchievement", () => {
 			const awarded = await get("triple_crown").check();
 			assert.strictEqual(awarded, false);
 		});
+	});
+});
+
+describe("revenge_2", () => {
+	const previousTid = 5;
+	const currentTid = 7;
+
+	beforeEach(async () => {
+		resetG();
+		g.setWithoutSavingToDB("season", 2013);
+		g.setWithoutSavingToDB("startingSeason", 2010);
+		g.setWithoutSavingToDB("userTid", [
+			{
+				start: -Infinity,
+				value: previousTid,
+			},
+			{
+				start: g.get("season"),
+				value: currentTid,
+			},
+		]);
+		g.setWithoutSavingToDB("userTids", [currentTid]);
+
+		const teamsDefault = helpers.getTeamsDefault();
+		const userTeamSeason = team.genSeasonRow(teamsDefault[currentTid]!);
+		userTeamSeason.playoffRoundsWon = g.get("numGamesPlayoffSeries").length;
+
+		await resetCache({
+			teams: teamsDefault.map(team.generate),
+			teamSeasons: [userTeamSeason],
+		});
+
+		await idb.cache.playoffSeries.put({
+			season: g.get("season"),
+			currentRound: 0,
+			series: [
+				[
+					{
+						home: {
+							tid: currentTid,
+							cid: 0,
+							winp: 0.75,
+							won: 4,
+							seed: 1,
+						},
+						away: {
+							tid: previousTid,
+							cid: 1,
+							winp: 0.7,
+							won: 2,
+							seed: 1,
+						},
+					},
+				],
+			],
+		});
+
+		idb.league = mockIDBLeague();
+	});
+
+	afterAll(() => {
+		// @ts-expect-error
+		idb.league = undefined;
+	});
+
+	test("awards achievement for winning finals against a team that fired the user", async () => {
+		g.setWithoutSavingToDB("firedTids", [
+			{
+				tid: previousTid,
+				season: g.get("season") - 1,
+			},
+		]);
+
+		const awarded = await get("revenge_2").check();
+		assert.strictEqual(awarded, true);
+	});
+
+	test("does not award achievement for a previously controlled team that did not fire the user", async () => {
+		g.setWithoutSavingToDB("firedTids", []);
+
+		const revengeAwarded = await get("revenge").check();
+		assert.strictEqual(revengeAwarded, true);
+
+		const revenge2Awarded = await get("revenge_2").check();
+		assert.strictEqual(revenge2Awarded, false);
 	});
 });

--- a/src/worker/util/achievements.test.ts
+++ b/src/worker/util/achievements.test.ts
@@ -780,14 +780,12 @@ describe("revenge_2", () => {
 						home: {
 							tid: currentTid,
 							cid: 0,
-							winp: 0.75,
 							won: 4,
 							seed: 1,
 						},
 						away: {
 							tid: previousTid,
 							cid: 1,
-							winp: 0.7,
 							won: 2,
 							seed: 1,
 						},

--- a/src/worker/util/achievements.ts
+++ b/src/worker/util/achievements.ts
@@ -1352,6 +1352,40 @@ const achievements: Achievement[] = [
 
 		when: "afterPlayoffs",
 	},
+	{
+		slug: "revenge_2",
+		name: "Revenge 2",
+		desc: "Win in the finals against a team that fired you.",
+		category: "Playoffs",
+
+		async check() {
+			const wonTitle = await userWonTitle();
+
+			if (!wonTitle) {
+				return false;
+			}
+
+			const playoffSeries = await idb.cache.playoffSeries.get(g.get("season"));
+
+			const matchup = playoffSeries?.series.at(-1)?.[0];
+
+			if (matchup === undefined || matchup.away === undefined) {
+				return false;
+			}
+
+			const loserTid =
+				matchup.home.won > matchup.away.won
+					? matchup.away.tid
+					: matchup.home.tid;
+
+			const currentSeason = g.get("season");
+			return g
+				.get("firedTids")
+				.some(({ tid, season }) => tid === loserTid && season < currentSeason);
+		},
+
+		when: "afterPlayoffs",
+	},
 ];
 
 if (isSport("hockey") || isSport("basketball")) {


### PR DESCRIPTION
## Summary
Adds a Revenge 2 achievement, awarded for winning the finals against a team that fired you, and records firings so the game can tell how a team change happened.

## Why this matters
> "Probably Revenge 1 should just be this, but currently it doesn't track how a team change happened."

That's your comment on #492. The existing Revenge achievement triggers for any team you previously controlled, including teams you left voluntarily through God Mode. This adds the missing tracking: when the owner fires you, `firedTids` records `{tid, season}` at the `gameOver: true` write site in `genMessage`. Revenge 2 checks the finals loser against that list.

If you would rather fold this semantics into Revenge 1 instead of adding a level 2, that's a one line swap now that the tracking exists. Happy either way.

## Changes
- `firedTids` is a plain array game attribute rather than a `[{start, value}]` history, so it needs no ALWAYS_WRAP entry and old leagues get the `[]` default from `loadGameAttributes` with no migration.
- Team contraction (`team/disable.ts`) also sets `gameOver: true` but intentionally does not record a firing, since a disbanded team didn't fire you.
- Tracking only covers firings that happen after this change. There's no way to backfill history.

## Demo
Screenshots:

![Revenge 2 in the achievements list](https://i.imgur.com/k195O7t.png)

## Testing
New vitest cases: being fired appends to `firedTids` and persists to teh gameAttributes store, Revenge 2 awards when the finals loser fired you, and does not award for a previously controlled team that didn't. `pnpm lint` and `pnpm test` pass.

Fixes #492
