### PR TITLE
Add God Mode setting to adjust draft prospect quality

### DIFF
--- a/src/common/defaultGameAttributes.ts
+++ b/src/common/defaultGameAttributes.ts
@@ -231,6 +231,7 @@ export const defaultGameAttributes: GameAttributesLeagueWithHistory = {
 	foulsUntilBonus: [5, 4, 2],
 	rookieContractLengths: [3, 2],
 	rookiesCanRefuse: true,
+	draftProspectQualityFactor: 1,
 
 	pace: 100,
 	threePointers: true,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -567,6 +567,7 @@ export type GameAttributesLeague = {
 	difficulty: number;
 	divs: NonEmptyArray<Div>;
 	draftAges: [number, number];
+	draftProspectQualityFactor: number;
 	draftPickAutoContract: boolean;
 	draftPickAutoContractPercent: number;
 	draftPickAutoContractRounds: number;

--- a/src/ui/views/Settings/settings.tsx
+++ b/src/ui/views/Settings/settings.tsx
@@ -686,6 +686,20 @@ export const settings: Setting[] = (
 		},
 		{
 			category: "Draft",
+			key: "draftProspectQualityFactor",
+			name: "Draft Prospect Quality Factor",
+			godModeRequired: "existingLeagueOnly",
+			type: "float",
+			description:
+				"A factor applied to the ratings of generated draft prospects. The default value is 1. Values above 1 create stronger prospects, and values below 1 create weaker prospects. This affects future generated draft prospects, including the initial rosters of new random-players leagues. In real-player leagues, this only applies to generated filler players.",
+			validator: (value) => {
+				if (value < 0) {
+					throw new Error("Value cannot be less than 0");
+				}
+			},
+		},
+		{
+			category: "Draft",
 			key: "draftAges",
 			name: "Age of Draft Prospects",
 			godModeRequired: "always",

--- a/src/ui/views/Settings/types.ts
+++ b/src/ui/views/Settings/types.ts
@@ -11,6 +11,7 @@ export type Key =
 	| "draftType"
 	| "numSeasonsFutureDraftPicks"
 	| "draftAges"
+	| "draftProspectQualityFactor"
 	| "salaryCap"
 	| "minPayroll"
 	| "luxuryPayroll"

--- a/src/worker/core/draft/genPlayers.test.ts
+++ b/src/worker/core/draft/genPlayers.test.ts
@@ -1,15 +1,32 @@
-import { assert, test } from "vitest";
-import { PLAYER } from "../../../common/constants.ts";
+import { afterEach, assert, test } from "vitest";
+import { PLAYER, RATINGS } from "../../../common/constants.ts";
 import { mockIDBLeague, resetCache, resetG } from "../../../test/helpers.ts";
 import { idb } from "../../db/index.ts";
-import { g } from "../../util/index.ts";
+import { g, helpers } from "../../util/index.ts";
 import { draft } from "../index.ts";
 import { DEFAULT_LEVEL } from "../../../common/budgetLevels.ts";
+import genPlayersWithoutSaving, {
+	scaleProspectRatings,
+} from "./genPlayersWithoutSaving.ts";
 
-test("generate 70 players for the draft", async () => {
+const setup = async () => {
 	resetG();
 	await resetCache();
 	idb.league = mockIDBLeague();
+};
+
+const meanRating = (
+	players: Awaited<ReturnType<typeof genPlayersWithoutSaving>>,
+	key: "ovr" | "pot",
+) => players.reduce((sum, p) => sum + p.ratings[0][key], 0) / players.length;
+
+afterEach(() => {
+	// @ts-expect-error
+	idb.league = undefined;
+});
+
+test("generate 70 players for the draft", async () => {
+	await setup();
 	await draft.genPlayers(g.get("season"), DEFAULT_LEVEL);
 	const players = await idb.cache.players.indexGetAll(
 		"playersByDraftYearRetiredYear",
@@ -20,7 +37,82 @@ test("generate 70 players for the draft", async () => {
 	for (const p of players) {
 		assert.strictEqual(p.tid, PLAYER.UNDRAFTED);
 	}
+});
 
-	// @ts-expect-error
-	idb.league = undefined;
+test("draft prospect quality factor neutral value leaves ratings unchanged", async () => {
+	await setup();
+	const players = await genPlayersWithoutSaving(
+		g.get("season"),
+		DEFAULT_LEVEL,
+		[],
+	);
+	const before = helpers.deepCopy(players);
+
+	await scaleProspectRatings(players, 1);
+
+	assert.deepStrictEqual(players, before);
+});
+
+test("draft prospect quality factor increases prospect quality", async () => {
+	await setup();
+	const neutralPlayers = await genPlayersWithoutSaving(
+		g.get("season"),
+		DEFAULT_LEVEL,
+		[],
+	);
+	const boostedPlayers = helpers.deepCopy(neutralPlayers);
+
+	await scaleProspectRatings(boostedPlayers, 2);
+
+	assert.isAbove(
+		meanRating(boostedPlayers, "ovr"),
+		meanRating(neutralPlayers, "ovr") + 10,
+	);
+	assert.isAbove(
+		meanRating(boostedPlayers, "pot"),
+		meanRating(neutralPlayers, "pot") + 10,
+	);
+});
+
+test("draft prospect quality factor clamps ratings", async () => {
+	await setup();
+	const players = await genPlayersWithoutSaving(
+		g.get("season"),
+		DEFAULT_LEVEL,
+		[],
+	);
+
+	await scaleProspectRatings(players, 1000);
+
+	for (const p of players) {
+		const ratings = p.ratings[0] as any;
+
+		for (const key of RATINGS) {
+			assert.isAtLeast(ratings[key], 0);
+			assert.isAtMost(ratings[key], 100);
+		}
+		assert.isAtLeast(ratings.ovr, 0);
+		assert.isAtMost(ratings.ovr, 100);
+		assert.isAtLeast(ratings.pot, 0);
+		assert.isAtMost(ratings.pot, 100);
+	}
+});
+
+test("draft prospect quality factor applies during draft player generation", async () => {
+	await setup();
+	g.setWithoutSavingToDB("draftProspectQualityFactor", 0);
+
+	const players = await genPlayersWithoutSaving(
+		g.get("season"),
+		DEFAULT_LEVEL,
+		[],
+	);
+
+	for (const p of players) {
+		const ratings = p.ratings[0] as any;
+
+		for (const key of RATINGS) {
+			assert.strictEqual(ratings[key], 0);
+		}
+	}
 });

--- a/src/worker/core/draft/genPlayersWithoutSaving.ts
+++ b/src/worker/core/draft/genPlayersWithoutSaving.ts
@@ -1,11 +1,12 @@
-import { PLAYER } from "../../../common/constants.ts";
+import { PLAYER, RATINGS } from "../../../common/constants.ts";
 import { player } from "../index.ts";
 import { g } from "../../util/index.ts";
 import type { PlayerWithoutKey } from "../../../common/types.ts";
 import { bySport, isSport } from "../../../common/sportFunctions.ts";
-import { minBy } from "../../../common/utils.ts";
+import { last, minBy } from "../../../common/utils.ts";
 import { randInt, shuffle } from "../../../common/random.ts";
 import { defaultGameAttributes } from "../../../common/defaultGameAttributes.ts";
+import limitRating from "../player/limitRating.ts";
 
 // To improve the distribution of DP ages in leagues with modified draftAges, this code will change the % of players who declare for draft each year to work better with modified draftAges settings. Previously, it was just a constant defaultFractionPerYear.
 const defaultFractionPerYear = bySport({
@@ -45,6 +46,25 @@ const getFractionPerYear = (ageGap: number) => {
 
 const developOneSeason = async (p: PlayerWithoutKey) => {
 	await player.develop(p, 1, true);
+};
+
+export const scaleProspectRatings = async (
+	players: PlayerWithoutKey[],
+	factor: number,
+) => {
+	if (factor === 1) {
+		return;
+	}
+
+	for (const p of players) {
+		const ratings = last(p.ratings) as any;
+
+		for (const key of RATINGS) {
+			ratings[key] = limitRating(ratings[key] * factor);
+		}
+
+		await player.develop(p, 0);
+	}
 };
 
 const genPlayersWithoutSaving = async (
@@ -183,6 +203,11 @@ const genPlayersWithoutSaving = async (
 			}
 		}
 	}
+
+	await scaleProspectRatings(
+		enteringDraft,
+		g.get("draftProspectQualityFactor"),
+	);
 
 	// If user has increased the number of rounds, ensure excess players are scrubs
 	if (normalNumPlayers < baseNumPlayers || forceScrubs) {

--- a/src/worker/views/newLeague.ts
+++ b/src/worker/views/newLeague.ts
@@ -81,6 +81,10 @@ export const getDefaultSettings = () => {
 		),
 		draftType: unwrapGameAttribute(defaultGameAttributes, "draftType"),
 		draftAges: unwrapGameAttribute(defaultGameAttributes, "draftAges"),
+		draftProspectQualityFactor: unwrapGameAttribute(
+			defaultGameAttributes,
+			"draftProspectQualityFactor",
+		),
 		playersRefuseToNegotiate: unwrapGameAttribute(
 			defaultGameAttributes,
 			"playersRefuseToNegotiate",

--- a/src/worker/views/settings.ts
+++ b/src/worker/views/settings.ts
@@ -49,6 +49,7 @@ type Key =
 	| "allStarType"
 	| "budget"
 	| "numSeasonsFutureDraftPicks"
+	| "draftProspectQualityFactor"
 	| "foulRateFactor"
 	| "foulsNeededToFoulOut"
 	| "foulsUntilBonus"
@@ -268,6 +269,7 @@ const updateSettings = async (inputs: unknown, updateEvents: UpdateEvents) => {
 			allStarType: g.get("allStarType"),
 			budget: g.get("budget"),
 			numSeasonsFutureDraftPicks: g.get("numSeasonsFutureDraftPicks"),
+			draftProspectQualityFactor: g.get("draftProspectQualityFactor"),
 			foulRateFactor: g.get("foulRateFactor"),
 			foulsNeededToFoulOut: g.get("foulsNeededToFoulOut"),
 			foulsUntilBonus: g.get("foulsUntilBonus"),


### PR DESCRIPTION
## Summary
Adds a God Mode setting, Draft Prospect Quality Factor, that scales the ratings of generated draft prospects. Values above 1 create stronger prospects, values below 1 weaker ones. The default is 1, so existing leagues see no change unless the setting is touched.

## Why this matters
#487 asks for a talent/potential modifier for draft prospects, with a spectator league use case where the pool of good players thins out over the years. tomkennedy22 +1'd it citing [OOTP's Player Creation Modifiers](https://manuals.ootpdevelopments.com/index.php?man=ootp22&page=advanced_players#fictional_player_settings) as genre prior art. The hook lives in `genPlayersWithoutSaving`, which already modulates prospect quality there (the scrub logic for extra draft rounds), and the factor is applied before that block so excess round players stay scrubs.

## Changes
- One knob, applied to each generated prospect's latest ratings, clamped through `limitRating`, with `player.develop(p, 0)` recomputing ovr and pot afterward.
- The same code path generates the initial rosters of new random players leagues (simulated draft classes), so the factor intentionally applies there too. The setting description says so.
- In real players leagues the factor only affects generated filler players.

## Demo
Screenshots:

The setting under League Settings > Draft (God Mode):

![setting in League Settings](https://i.imgur.com/X9ax3mp.png)

With the factor at 4, a regenerated 2026 class next to untouched 2027/2028 baselines:

![regenerated class vs baseline](https://i.imgur.com/WXcrTa2.png)

## Testing
Rewrote the genPlayers test around the unseeded RNG: applying the neutral factor leaves every rating byte identical, and a boosted class generated in the same run has a higher mean ovr than a neutral one. `pnpm lint` and `pnpm test` pass.

Fixes #487
