### PR TITLE
Add player development breakdown (age/coaching/variance) to ratings history

### DIFF
--- a/src/common/types.baseball.ts
+++ b/src/common/types.baseball.ts
@@ -131,6 +131,7 @@ export type PlayerRatings = {
 	ovrs: Record<Position, number>;
 	pots: Record<Position, number>;
 	pos: string;
+	progBreakdown?: [number, number, number];
 	season: number;
 	skills: string[];
 };

--- a/src/common/types.basketball.ts
+++ b/src/common/types.basketball.ts
@@ -142,6 +142,7 @@ export type PlayerRatings = {
 	ovr: number;
 	pos: string;
 	pot: number;
+	progBreakdown?: [number, number, number];
 	pss: number;
 	reb: number;
 	season: number;

--- a/src/common/types.football.ts
+++ b/src/common/types.football.ts
@@ -208,6 +208,7 @@ export type PlayerRatings = {
 	ovrs: Record<Position, number>;
 	pots: Record<Position, number>;
 	pos: string;
+	progBreakdown?: [number, number, number];
 	season: number;
 	skills: string[];
 	injuryIndex?: number;

--- a/src/common/types.hockey.ts
+++ b/src/common/types.hockey.ts
@@ -107,6 +107,7 @@ export type PlayerRatings = {
 	ovrs: Record<Position, number>;
 	pots: Record<Position, number>;
 	pos: string;
+	progBreakdown?: [number, number, number];
 	season: number;
 	skills: string[];
 };

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1146,6 +1146,7 @@ export type MinimalPlayerRatings = {
 	season: number;
 	ovrs?: any;
 	pots?: any;
+	progBreakdown?: [number, number, number];
 	injuryIndex?: number;
 	hgt: number;
 	spd: number;

--- a/src/ui/views/Player/RatingsOverview.tsx
+++ b/src/ui/views/Player/RatingsOverview.tsx
@@ -3,7 +3,23 @@ import { posRatings } from "../../../common/posRatings.ts";
 import { bySport } from "../../../common/sportFunctions.ts";
 import { ratingsGradientStyle } from "../../components/RatingsStatsPopover/ratingsGradientStyle.ts";
 import { RatingWithChange } from "../../components/RatingWithChange.tsx";
-import { type ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
+
+const developmentLabels = ["Age", "Coaching", "Variance"] as const;
+
+const formatDevelopmentChange = (change: number) => {
+	return `${change > 0 ? "+" : ""}${change.toFixed(1)}`;
+};
+
+const getDevelopmentChangeClassName = (change: number) => {
+	if (change > 0) {
+		return "text-success";
+	}
+
+	if (change < 0) {
+		return "text-danger";
+	}
+};
 
 export const RatingsOverview = ({
 	ratings,
@@ -24,6 +40,11 @@ export const RatingsOverview = ({
 	const lastSeason =
 		ratings.findLast((row) => row.season === currentSeason.season - 1) ??
 		currentSeason;
+	const progBreakdown: [number, number, number] | undefined =
+		Array.isArray(currentSeason.progBreakdown) &&
+		currentSeason.progBreakdown.length === 3
+			? currentSeason.progBreakdown
+			: undefined;
 
 	const columns = bySport<
 		Record<
@@ -502,6 +523,27 @@ export const RatingsOverview = ({
 					</RatingWithChange>
 				</h2>
 			</div>
+			{progBreakdown ? (
+				<div
+					className="small text-body-secondary mb-2"
+					title="Average per-rating change from this season's development"
+				>
+					Development:{" "}
+					{developmentLabels.map((label, i) => {
+						const change = progBreakdown[i]!;
+
+						return (
+							<Fragment key={label}>
+								{i > 0 ? " / " : null}
+								{label}{" "}
+								<span className={getDevelopmentChangeClassName(change)}>
+									{formatDevelopmentChange(change)}
+								</span>
+							</Fragment>
+						);
+					})}
+				</div>
+			) : null}
 			<div className="d-flex justify-content-between">
 				{columns.map((column, i) => (
 					<div key={i} className={i === 0 ? undefined : "ms-2 ms-sm-5"}>

--- a/src/worker/core/phase/newPhasePreseason.ts
+++ b/src/worker/core/phase/newPhasePreseason.ts
@@ -375,6 +375,7 @@ const newPhasePreseason = async (
 			);
 			if (newRatings) {
 				newRatings.season += 1;
+				newRatings.progBreakdown = undefined;
 				p.ratings.push(newRatings);
 			}
 

--- a/src/worker/core/player/addRatingsRow.ts
+++ b/src/worker/core/player/addRatingsRow.ts
@@ -15,6 +15,7 @@ const addRatingsRow = (
 		...last(p.ratings),
 		season: g.get("season"),
 		injuryIndex: undefined,
+		progBreakdown: undefined,
 	};
 
 	if (scoutingLevel !== undefined) {

--- a/src/worker/core/player/develop.ts
+++ b/src/worker/core/player/develop.ts
@@ -18,6 +18,10 @@ import { TOO_MANY_TEAMS_TOO_SLOW } from "../season/getInitialNumGamesConfDivSett
 import { DEFAULT_LEVEL } from "../../../common/budgetLevels.ts";
 import { bySport, isSport } from "../../../common/sportFunctions.ts";
 import { last } from "../../../common/utils.ts";
+import {
+	addToProgBreakdown,
+	type ProgBreakdown,
+} from "./developmentBreakdown.ts";
 
 const NUM_SIMULATIONS = 20; // Higher is more accurate, but slower. Low accuracy is fine, though!
 
@@ -128,6 +132,9 @@ const develop = async (
 ) => {
 	const ratings = last(p.ratings);
 	let age = ratings.season - p.born.year;
+	const shouldSaveProgBreakdown =
+		!newPlayer && years === 1 && p.ratings.length > 1;
+	const progBreakdown: ProgBreakdown = [0, 0, 0];
 
 	for (let i = 0; i < years; i++) {
 		// (CONFUSING!) Don't increment age for existing players developing one season (i.e. newPhasePreseason) because the season is already incremented before this function is called. But in other scenarios (new league and draft picks), the season is not changing, so age should be incremented every iteration of this loop.
@@ -136,7 +143,17 @@ const develop = async (
 		}
 
 		if (!ratings.locked) {
-			await developSeason(ratings, age, p.srID, coachingLevel, false);
+			const seasonProgBreakdown = await developSeason(
+				ratings,
+				age,
+				p.srID,
+				coachingLevel,
+				false,
+			);
+
+			if (shouldSaveProgBreakdown) {
+				addToProgBreakdown(progBreakdown, seasonProgBreakdown);
+			}
 		}
 	}
 
@@ -195,6 +212,10 @@ const develop = async (
 			ratings.pot = ratings.pots[pos];
 			ratings.pos = pos;
 		}
+	}
+
+	if (shouldSaveProgBreakdown && !ratings.locked) {
+		ratings.progBreakdown = progBreakdown;
 	}
 
 	if (!ratings.locked && years > 0) {

--- a/src/worker/core/player/developSeason.baseball.ts
+++ b/src/worker/core/player/developSeason.baseball.ts
@@ -1,11 +1,15 @@
-import limitRating from "./limitRating.ts";
 import { helpers } from "../../util/index.ts";
 import type {
 	PlayerRatings,
 	RatingKey,
 } from "../../../common/types.baseball.ts";
-import { coachingEffect } from "../../../common/budgetLevels.ts";
 import { truncGauss, uniform } from "../../../common/random.ts";
+import {
+	addToProgBreakdown,
+	getBaseChange,
+	getRatingChangeBreakdown,
+	type ProgBreakdown,
+} from "./developmentBreakdown.ts";
 
 type RatingFormula = {
 	ageModifier: (age: number) => number;
@@ -202,41 +206,41 @@ const ratingsFormulas: Record<Exclude<RatingKey, "hgt">, RatingFormula> = {
 	endu: powerFormula,
 };
 
-const calcBaseChange = (age: number, coachingLevel: number): number => {
-	let val: number;
+const calcBaseChange = (age: number, coachingLevel: number) => {
+	let ageChange: number;
 
 	if (age <= 21) {
-		val = 2;
+		ageChange = 2;
 	} else if (age <= 25) {
-		val = 1;
+		ageChange = 1;
 	} else if (age <= 27) {
-		val = 0;
+		ageChange = 0;
 	} else if (age <= 29) {
-		val = -1;
+		ageChange = -1;
 	} else if (age <= 31) {
-		val = -2;
+		ageChange = -2;
 	} else if (age <= 33) {
-		val = -3;
+		ageChange = -3;
 	} else if (age <= 35) {
-		val = -4;
+		ageChange = -4;
 	} else if (age <= 37) {
-		val = -5;
+		ageChange = -5;
 	} else {
-		val = -6;
+		ageChange = -6;
 	}
+
+	let randomChange;
 
 	// Noise
 	if (age <= 23) {
-		val += truncGauss(0, 5, -4, 15);
+		randomChange = truncGauss(0, 5, -4, 15);
 	} else if (age <= 25) {
-		val += truncGauss(0, 5, -4, 7);
+		randomChange = truncGauss(0, 5, -4, 7);
 	} else {
-		val += truncGauss(0, 3, -2, 3);
+		randomChange = truncGauss(0, 3, -2, 3);
 	}
 
-	val *= 1 + (val > 0 ? 1 : -1) * coachingEffect(coachingLevel);
-
-	return val;
+	return getBaseChange(ageChange, randomChange, coachingLevel);
 };
 
 const developSeason = (
@@ -244,6 +248,8 @@ const developSeason = (
 	age: number,
 	coachingLevel: number,
 ) => {
+	const progBreakdown: ProgBreakdown = [0, 0, 0];
+
 	// In young players, height can sometimes increase
 	if (age <= 21) {
 		const heightRand = Math.random();
@@ -272,15 +278,20 @@ const developSeason = (
 			}
 		}
 
-		ratings[key] = limitRating(
-			ratings[key] +
-				helpers.bound(
-					(baseChange + ageModifier) * uniform(0.6, 1.3),
-					changeLimits[0],
-					changeLimits[1],
-				),
-		);
+		const { newRating, progBreakdown: ratingProgBreakdown } =
+			getRatingChangeBreakdown({
+				ageModifier,
+				baseChange,
+				changeLimits,
+				factor: uniform(0.6, 1.3),
+				oldRating: ratings[key],
+			});
+
+		ratings[key] = newRating;
+		addToProgBreakdown(progBreakdown, ratingProgBreakdown);
 	}
+
+	return progBreakdown;
 };
 
 export default developSeason;

--- a/src/worker/core/player/developSeason.basketball.ts
+++ b/src/worker/core/player/developSeason.basketball.ts
@@ -1,11 +1,15 @@
-import limitRating from "./limitRating.ts";
 import { helpers } from "../../util/index.ts";
 import type {
 	PlayerRatings,
 	RatingKey,
 } from "../../../common/types.basketball.ts";
-import { coachingEffect } from "../../../common/budgetLevels.ts";
 import { uniform, realGauss } from "../../../common/random.ts";
+import {
+	addToProgBreakdown,
+	getBaseChange,
+	getRatingChangeBreakdown,
+	type ProgBreakdown,
+} from "./developmentBreakdown.ts";
 
 type RatingFormula = {
 	ageModifier: (age: number) => number;
@@ -168,41 +172,41 @@ const ratingsFormulas: Record<Exclude<RatingKey, "hgt">, RatingFormula> = {
 	},
 };
 
-const calcBaseChange = (age: number, coachingLevel: number): number => {
-	let val: number;
+const calcBaseChange = (age: number, coachingLevel: number) => {
+	let ageChange: number;
 
 	if (age <= 21) {
-		val = 2;
+		ageChange = 2;
 	} else if (age <= 25) {
-		val = 1;
+		ageChange = 1;
 	} else if (age <= 27) {
-		val = 0;
+		ageChange = 0;
 	} else if (age <= 29) {
-		val = -1;
+		ageChange = -1;
 	} else if (age <= 31) {
-		val = -2;
+		ageChange = -2;
 	} else if (age <= 34) {
-		val = -3;
+		ageChange = -3;
 	} else if (age <= 40) {
-		val = -4;
+		ageChange = -4;
 	} else if (age <= 43) {
-		val = -5;
+		ageChange = -5;
 	} else {
-		val = -6;
+		ageChange = -6;
 	}
+
+	let randomChange;
 
 	// Noise
 	if (age <= 23) {
-		val += helpers.bound(realGauss(0, 5), -4, 20);
+		randomChange = helpers.bound(realGauss(0, 5), -4, 20);
 	} else if (age <= 25) {
-		val += helpers.bound(realGauss(0, 5), -4, 10);
+		randomChange = helpers.bound(realGauss(0, 5), -4, 10);
 	} else {
-		val += helpers.bound(realGauss(0, 3), -2, 4);
+		randomChange = helpers.bound(realGauss(0, 3), -2, 4);
 	}
 
-	val *= 1 + (val > 0 ? 1 : -1) * coachingEffect(coachingLevel);
-
-	return val;
+	return getBaseChange(ageChange, randomChange, coachingLevel);
 };
 
 const developSeason = (
@@ -210,6 +214,8 @@ const developSeason = (
 	age: number,
 	coachingLevel: number,
 ) => {
+	const progBreakdown: ProgBreakdown = [0, 0, 0];
+
 	// In young players, height can sometimes increase
 	if (age <= 21) {
 		const heightRand = Math.random();
@@ -228,16 +234,20 @@ const developSeason = (
 	for (const key of helpers.keys(ratingsFormulas)) {
 		const ageModifier = ratingsFormulas[key].ageModifier(age);
 		const changeLimits = ratingsFormulas[key].changeLimits(age);
+		const { newRating, progBreakdown: ratingProgBreakdown } =
+			getRatingChangeBreakdown({
+				ageModifier,
+				baseChange,
+				changeLimits,
+				factor: uniform(0.4, 1.4),
+				oldRating: ratings[key],
+			});
 
-		ratings[key] = limitRating(
-			ratings[key] +
-				helpers.bound(
-					(baseChange + ageModifier) * uniform(0.4, 1.4),
-					changeLimits[0],
-					changeLimits[1],
-				),
-		);
+		ratings[key] = newRating;
+		addToProgBreakdown(progBreakdown, ratingProgBreakdown);
 	}
+
+	return progBreakdown;
 };
 
 export default developSeason;

--- a/src/worker/core/player/developSeason.football.ts
+++ b/src/worker/core/player/developSeason.football.ts
@@ -1,11 +1,15 @@
-import limitRating from "./limitRating.ts";
 import { helpers } from "../../util/index.ts";
 import type {
 	PlayerRatings,
 	RatingKey,
 } from "../../../common/types.football.ts";
-import { coachingEffect } from "../../../common/budgetLevels.ts";
 import { uniform, truncGauss } from "../../../common/random.ts";
+import {
+	addToProgBreakdown,
+	getBaseChange,
+	getRatingChangeBreakdown,
+	type ProgBreakdown,
+} from "./developmentBreakdown.ts";
 
 type RatingFormula = {
 	ageModifier: (age: number) => number;
@@ -121,37 +125,37 @@ const ratingsFormulas: Record<Exclude<RatingKey, "hgt">, RatingFormula> = {
 	pac: iqFormula,
 };
 
-const calcBaseChange = (age: number, coachingLevel: number): number => {
-	let val: number;
+const calcBaseChange = (age: number, coachingLevel: number) => {
+	let ageChange: number;
 
 	if (age <= 21) {
-		val = 2;
+		ageChange = 2;
 	} else if (age <= 25) {
-		val = 1;
+		ageChange = 1;
 	} else if (age <= 27) {
-		val = 0;
+		ageChange = 0;
 	} else if (age <= 29) {
-		val = -1;
+		ageChange = -1;
 	} else if (age <= 31) {
-		val = -2;
+		ageChange = -2;
 	} else if (age <= 34) {
-		val = -3;
+		ageChange = -3;
 	} else {
-		val = -4;
+		ageChange = -4;
 	}
+
+	let randomChange;
 
 	// Noise
 	if (age <= 23) {
-		val += truncGauss(0, 5, -4, 15);
+		randomChange = truncGauss(0, 5, -4, 15);
 	} else if (age <= 25) {
-		val += truncGauss(0, 5, -4, 7);
+		randomChange = truncGauss(0, 5, -4, 7);
 	} else {
-		val += truncGauss(0, 3, -2, 3);
+		randomChange = truncGauss(0, 3, -2, 3);
 	}
 
-	val *= 1 + (val > 0 ? 1 : -1) * coachingEffect(coachingLevel);
-
-	return val;
+	return getBaseChange(ageChange, randomChange, coachingLevel);
 };
 
 const developSeason = (
@@ -159,6 +163,8 @@ const developSeason = (
 	age: number,
 	coachingLevel: number,
 ) => {
+	const progBreakdown: ProgBreakdown = [0, 0, 0];
+
 	// In young players, height can sometimes increase
 	if (age <= 21) {
 		const heightRand = Math.random();
@@ -187,15 +193,20 @@ const developSeason = (
 			}
 		}
 
-		ratings[key] = limitRating(
-			ratings[key] +
-				helpers.bound(
-					(baseChange + ageModifier) * uniform(0.4, 1.4),
-					changeLimits[0],
-					changeLimits[1],
-				),
-		);
+		const { newRating, progBreakdown: ratingProgBreakdown } =
+			getRatingChangeBreakdown({
+				ageModifier,
+				baseChange,
+				changeLimits,
+				factor: uniform(0.4, 1.4),
+				oldRating: ratings[key],
+			});
+
+		ratings[key] = newRating;
+		addToProgBreakdown(progBreakdown, ratingProgBreakdown);
 	}
+
+	return progBreakdown;
 };
 
 export default developSeason;

--- a/src/worker/core/player/developSeason.hockey.ts
+++ b/src/worker/core/player/developSeason.hockey.ts
@@ -1,8 +1,12 @@
-import limitRating from "./limitRating.ts";
 import { helpers } from "../../util/index.ts";
 import type { PlayerRatings, RatingKey } from "../../../common/types.hockey.ts";
-import { coachingEffect } from "../../../common/budgetLevels.ts";
 import { uniform, realGauss } from "../../../common/random.ts";
+import {
+	addToProgBreakdown,
+	getBaseChange,
+	getRatingChangeBreakdown,
+	type ProgBreakdown,
+} from "./developmentBreakdown.ts";
 
 type RatingFormula = {
 	ageModifier: (age: number) => number;
@@ -143,41 +147,41 @@ const ratingsFormulas: Record<Exclude<RatingKey, "hgt">, RatingFormula> = {
 	},
 };
 
-const calcBaseChange = (age: number, coachingLevel: number): number => {
-	let val: number;
+const calcBaseChange = (age: number, coachingLevel: number) => {
+	let ageChange: number;
 
 	if (age <= 21) {
-		val = 2;
+		ageChange = 2;
 	} else if (age <= 25) {
-		val = 1;
+		ageChange = 1;
 	} else if (age <= 27) {
-		val = 0;
+		ageChange = 0;
 	} else if (age <= 29) {
-		val = -1;
+		ageChange = -1;
 	} else if (age <= 31) {
-		val = -2;
+		ageChange = -2;
 	} else if (age <= 34) {
-		val = -3;
+		ageChange = -3;
 	} else if (age <= 40) {
-		val = -4;
+		ageChange = -4;
 	} else if (age <= 43) {
-		val = -5;
+		ageChange = -5;
 	} else {
-		val = -6;
+		ageChange = -6;
 	}
+
+	let randomChange;
 
 	// Noise
 	if (age <= 23) {
-		val += helpers.bound(realGauss(0, 5), -4, 20);
+		randomChange = helpers.bound(realGauss(0, 5), -4, 20);
 	} else if (age <= 25) {
-		val += helpers.bound(realGauss(0, 5), -4, 10);
+		randomChange = helpers.bound(realGauss(0, 5), -4, 10);
 	} else {
-		val += helpers.bound(realGauss(0, 3), -2, 4);
+		randomChange = helpers.bound(realGauss(0, 3), -2, 4);
 	}
 
-	val *= 1 + (val > 0 ? 1 : -1) * coachingEffect(coachingLevel);
-
-	return val;
+	return getBaseChange(ageChange, randomChange, coachingLevel);
 };
 
 const developSeason = (
@@ -185,6 +189,8 @@ const developSeason = (
 	age: number,
 	coachingLevel: number,
 ) => {
+	const progBreakdown: ProgBreakdown = [0, 0, 0];
+
 	// In young players, height can sometimes increase
 	if (age <= 21) {
 		const heightRand = Math.random();
@@ -204,17 +210,21 @@ const developSeason = (
 		const posCoeff = ratingsFormulas[key].posCoeff(ratings.pos);
 		const ageModifier = ratingsFormulas[key].ageModifier(age);
 		const changeLimits = ratingsFormulas[key].changeLimits(age);
+		const { newRating, progBreakdown: ratingProgBreakdown } =
+			getRatingChangeBreakdown({
+				ageModifier,
+				baseChange,
+				changeLimits,
+				factor: uniform(0.2, 1.2),
+				oldRating: ratings[key],
+				scale: posCoeff,
+			});
 
-		ratings[key] = limitRating(
-			ratings[key] +
-				posCoeff *
-					helpers.bound(
-						(baseChange + ageModifier) * uniform(0.2, 1.2),
-						changeLimits[0],
-						changeLimits[1],
-					),
-		);
+		ratings[key] = newRating;
+		addToProgBreakdown(progBreakdown, ratingProgBreakdown);
 	}
+
+	return progBreakdown;
 };
 
 export default developSeason;

--- a/src/worker/core/player/developSeason.ts
+++ b/src/worker/core/player/developSeason.ts
@@ -67,12 +67,16 @@ const developSeason = async (
 				const realRatings = groupedRatings[`${srID}_${targetSeason}`];
 
 				if (realRatings) {
+					const simulatedShare = 1 - realPlayerDeterminism;
 					for (const key of RATINGS) {
 						(ratings as any)[key] = limitRating(
 							realPlayerDeterminism * (realRatings as any)[key] +
-								(1 - realPlayerDeterminism) * (ratings as any)[key],
+								simulatedShare * (ratings as any)[key],
 						);
 					}
+					progBreakdown[0] *= simulatedShare;
+					progBreakdown[1] *= simulatedShare;
+					progBreakdown[2] *= simulatedShare;
 				}
 			}
 		}

--- a/src/worker/core/player/developSeason.ts
+++ b/src/worker/core/player/developSeason.ts
@@ -9,9 +9,23 @@ import loadDataBasketball from "../realRosters/loadData.basketball.ts";
 import type { Ratings } from "../realRosters/loadData.basketball.ts";
 import limitRating from "./limitRating.ts";
 import { bySport, isSport } from "../../../common/sportFunctions.ts";
+import {
+	finalizeProgBreakdown,
+	type ProgBreakdown,
+} from "./developmentBreakdown.ts";
 
 // Cache for performance
 let groupedRatings: Record<string, Ratings> | undefined;
+
+const getRatingsTotal = (ratings: MinimalPlayerRatings) => {
+	let total = 0;
+
+	for (const key of RATINGS) {
+		total += (ratings as any)[key];
+	}
+
+	return total;
+};
 
 const developSeason = async (
 	ratings: MinimalPlayerRatings,
@@ -20,56 +34,55 @@ const developSeason = async (
 	coachingLevel: number,
 	forPot: boolean,
 ) => {
-	bySport({
+	const ratingsTotalBefore = getRatingsTotal(ratings);
+	const progBreakdown = bySport<ProgBreakdown>({
 		baseball: developSeasonBaseball(ratings as any, age, coachingLevel),
 		basketball: developSeasonBasketball(ratings as any, age, coachingLevel),
 		football: developSeasonFootball(ratings as any, age, coachingLevel),
 		hockey: developSeasonHockey(ratings as any, age, coachingLevel),
 	});
 
-	if (!isSport("basketball") || !Object.hasOwn(g, "realPlayerDeterminism")) {
-		return;
-	}
+	if (
+		isSport("basketball") &&
+		Object.hasOwn(g, "realPlayerDeterminism") &&
+		(!forPot || g.get("rpdPot")) &&
+		srID !== undefined
+	) {
+		const realPlayerDeterminism =
+			helpers.bound(g.get("realPlayerDeterminism"), 0, 1) ** 2;
+		if (realPlayerDeterminism > 0) {
+			const basketball = await loadDataBasketball();
+			const bio = basketball.bios[srID];
 
-	if (forPot && !g.get("rpdPot")) {
-		return;
-	}
+			if (bio) {
+				if (!groupedRatings) {
+					groupedRatings = {};
+					for (const row of basketball.ratings) {
+						groupedRatings[`${row.slug}_${row.season}`] = row;
+					}
+				}
 
-	if (srID === undefined) {
-		return;
-	}
+				// Find real ratings with same age - can't just use season to look it up, because legends and random debut
+				const targetSeason = bio.bornYear + age;
+				const realRatings = groupedRatings[`${srID}_${targetSeason}`];
 
-	const realPlayerDeterminism =
-		helpers.bound(g.get("realPlayerDeterminism"), 0, 1) ** 2;
-	if (realPlayerDeterminism === 0) {
-		return;
-	}
-
-	const basketball = await loadDataBasketball();
-	const bio = basketball.bios[srID];
-	if (!bio) {
-		return;
-	}
-
-	if (!groupedRatings) {
-		groupedRatings = {};
-		for (const row of basketball.ratings) {
-			groupedRatings[`${row.slug}_${row.season}`] = row;
+				if (realRatings) {
+					for (const key of RATINGS) {
+						(ratings as any)[key] = limitRating(
+							realPlayerDeterminism * (realRatings as any)[key] +
+								(1 - realPlayerDeterminism) * (ratings as any)[key],
+						);
+					}
+				}
+			}
 		}
 	}
 
-	// Find real ratings with same age - can't just use season to look it up, because legends and random debut
-	const targetSeason = bio.bornYear + age;
-	const realRatings = groupedRatings[`${srID}_${targetSeason}`];
-
-	if (realRatings) {
-		for (const key of RATINGS) {
-			(ratings as any)[key] = limitRating(
-				realPlayerDeterminism * (realRatings as any)[key] +
-					(1 - realPlayerDeterminism) * (ratings as any)[key],
-			);
-		}
-	}
+	return finalizeProgBreakdown(
+		progBreakdown,
+		getRatingsTotal(ratings) - ratingsTotalBefore,
+		RATINGS.length,
+	);
 };
 
 export default developSeason;

--- a/src/worker/core/player/developmentBreakdown.test.ts
+++ b/src/worker/core/player/developmentBreakdown.test.ts
@@ -1,0 +1,74 @@
+import { assert, test } from "vitest";
+import { RATINGS, PLAYER } from "../../../common/constants.ts";
+import { DEFAULT_LEVEL } from "../../../common/budgetLevels.ts";
+import { resetG } from "../../../test/helpers.ts";
+import { g } from "../../util/index.ts";
+import { last } from "../../../common/utils.ts";
+import player from "./index.ts";
+import {
+	finalizeProgBreakdown,
+	getBaseChange,
+	getRatingChangeBreakdown,
+} from "./developmentBreakdown.ts";
+
+test("rating development breakdown components sum to the applied rating change", () => {
+	const baseChange = getBaseChange(2, -0.75, 80);
+	const { newRating, progBreakdown } = getRatingChangeBreakdown({
+		ageModifier: 1.5,
+		baseChange,
+		changeLimits: [-12, 12],
+		factor: 0.9,
+		oldRating: 50,
+	});
+
+	assert.closeTo(
+		progBreakdown[0] + progBreakdown[1] + progBreakdown[2],
+		newRating - 50,
+		1e-12,
+	);
+});
+
+test("finalized development breakdown components sum to the average rating change", () => {
+	assert.deepStrictEqual(
+		finalizeProgBreakdown([3, 1, 100], 6, 2),
+		[1.5, 0.5, 1],
+	);
+});
+
+test("annual development stores a rounded breakdown on the new ratings row", async () => {
+	resetG();
+	const p = player.generate(
+		PLAYER.FREE_AGENT,
+		19,
+		g.get("season"),
+		false,
+		DEFAULT_LEVEL,
+	);
+
+	g.setWithoutSavingToDB("season", g.get("season") + 1);
+	player.addRatingsRow(p);
+
+	const ratings = last(p.ratings);
+	const ratingsTotalBefore = getRatingsTotal(ratings);
+	await player.develop(p, 1, false, DEFAULT_LEVEL, true);
+	const ratingsTotalAfter = getRatingsTotal(ratings);
+	const progBreakdown = ratings.progBreakdown;
+
+	assert(progBreakdown);
+	assert.strictEqual(progBreakdown.length, 3);
+	assert.closeTo(
+		progBreakdown[0] + progBreakdown[1] + progBreakdown[2],
+		(ratingsTotalAfter - ratingsTotalBefore) / RATINGS.length,
+		0.151,
+	);
+});
+
+const getRatingsTotal = (ratings: any) => {
+	let total = 0;
+
+	for (const key of RATINGS) {
+		total += ratings[key];
+	}
+
+	return total;
+};

--- a/src/worker/core/player/developmentBreakdown.ts
+++ b/src/worker/core/player/developmentBreakdown.ts
@@ -1,0 +1,96 @@
+import { coachingEffect } from "../../../common/budgetLevels.ts";
+import { helpers } from "../../util/index.ts";
+import limitRating from "./limitRating.ts";
+
+export type ProgBreakdown = [number, number, number];
+
+type BaseChangeBreakdown = {
+	age: number;
+	coaching: number;
+	total: number;
+};
+
+export const addToProgBreakdown = (
+	total: ProgBreakdown,
+	added: ProgBreakdown,
+) => {
+	total[0] += added[0];
+	total[1] += added[1];
+	total[2] += added[2];
+};
+
+export const finalizeProgBreakdown = (
+	progBreakdown: ProgBreakdown,
+	finalTotalChange: number,
+	numRatings: number,
+): ProgBreakdown => {
+	const age = progBreakdown[0];
+	const coaching = progBreakdown[1];
+
+	return [
+		roundRatingChange(age / numRatings),
+		roundRatingChange(coaching / numRatings),
+		roundRatingChange((finalTotalChange - age - coaching) / numRatings),
+	];
+};
+
+export const getBaseChange = (
+	ageChange: number,
+	randomChange: number,
+	coachingLevel: number,
+): BaseChangeBreakdown => {
+	const beforeCoaching = ageChange + randomChange;
+	const total =
+		beforeCoaching *
+		(1 + (beforeCoaching > 0 ? 1 : -1) * coachingEffect(coachingLevel));
+
+	return {
+		age: ageChange,
+		coaching: total - beforeCoaching,
+		total,
+	};
+};
+
+export const getRatingChangeBreakdown = ({
+	ageModifier,
+	baseChange,
+	changeLimits,
+	factor,
+	oldRating,
+	scale = 1,
+}: {
+	ageModifier: number;
+	baseChange: BaseChangeBreakdown;
+	changeLimits: [number, number];
+	factor: number;
+	oldRating: number;
+	scale?: number;
+}): {
+	newRating: number;
+	progBreakdown: ProgBreakdown;
+} => {
+	const boundedChange = helpers.bound(
+		(baseChange.total + ageModifier) * factor,
+		changeLimits[0],
+		changeLimits[1],
+	);
+	const newRating = limitRating(oldRating + scale * boundedChange);
+	const appliedChange = newRating - oldRating;
+	const age = scale * (baseChange.age + ageModifier) * factor;
+	const coaching = scale * baseChange.coaching * factor;
+
+	return {
+		newRating,
+		progBreakdown: [age, coaching, appliedChange - age - coaching],
+	};
+};
+
+const roundRatingChange = (change: number) => {
+	const rounded = Math.round(change * 10) / 10;
+
+	if (Object.is(rounded, -0)) {
+		return 0;
+	}
+
+	return rounded;
+};

--- a/src/worker/db/getCopies/playersPlus.ts
+++ b/src/worker/db/getCopies/playersPlus.ts
@@ -474,7 +474,11 @@ const processRatings = (
 			} else if (attr === "age") {
 				row.age = pr.season - p.born.year;
 			} else if (attr === "progBreakdown") {
-				if (!fuzz && pr.progBreakdown !== undefined) {
+				// Mirror fuzzRating: fuzz is effectively disabled in god mode and
+				// multi team mode, so the exact breakdown leaks nothing there.
+				const fuzzApplies =
+					fuzz && !g.get("godMode") && g.get("userTids").length <= 1;
+				if (!fuzzApplies && pr.progBreakdown !== undefined) {
 					row.progBreakdown = [...pr.progBreakdown];
 				}
 			} else if (attr === "abbrev" || attr === "tid") {
@@ -553,7 +557,7 @@ const processRatings = (
 					row.pos = last(p.ratings).pos;
 				} else if (attr === "abbrev") {
 					row.abbrev = "";
-				} else if (!fuzz || attr !== "progBreakdown") {
+				} else if (attr !== "progBreakdown") {
 					row[attr] = 0;
 				}
 			}

--- a/src/worker/db/getCopies/playersPlus.ts
+++ b/src/worker/db/getCopies/playersPlus.ts
@@ -473,6 +473,10 @@ const processRatings = (
 				}
 			} else if (attr === "age") {
 				row.age = pr.season - p.born.year;
+			} else if (attr === "progBreakdown") {
+				if (pr.progBreakdown !== undefined) {
+					row.progBreakdown = [...pr.progBreakdown];
+				}
 			} else if (attr === "abbrev" || attr === "tid") {
 				// Find the last stats entry for that season, and use that to determine the team. Requires tid to be requested from stats (otherwise, need to refactor stats fetching to happen outside of processStats)
 				if (!stats.includes("tid")) {

--- a/src/worker/db/getCopies/playersPlus.ts
+++ b/src/worker/db/getCopies/playersPlus.ts
@@ -474,7 +474,7 @@ const processRatings = (
 			} else if (attr === "age") {
 				row.age = pr.season - p.born.year;
 			} else if (attr === "progBreakdown") {
-				if (pr.progBreakdown !== undefined) {
+				if (!fuzz && pr.progBreakdown !== undefined) {
 					row.progBreakdown = [...pr.progBreakdown];
 				}
 			} else if (attr === "abbrev" || attr === "tid") {
@@ -553,7 +553,7 @@ const processRatings = (
 					row.pos = last(p.ratings).pos;
 				} else if (attr === "abbrev") {
 					row.abbrev = "";
-				} else {
+				} else if (!fuzz || attr !== "progBreakdown") {
 					row[attr] = 0;
 				}
 			}

--- a/src/worker/views/player.ts
+++ b/src/worker/views/player.ts
@@ -141,6 +141,7 @@ export const getPlayer = async (
 			...RATINGS,
 			"skills",
 			"pos",
+			"progBreakdown",
 			"injuryIndex",
 		],
 		stats: ["season", "tid", "abbrev", "age", "jerseyNumber", ...stats],

--- a/tools/build/generateJsonSchema.ts
+++ b/tools/build/generateJsonSchema.ts
@@ -22,6 +22,14 @@ const genRatings = (sport: Sport) => {
 			minimum: 0,
 			maximum: 100,
 		},
+		progBreakdown: {
+			type: "array",
+			items: {
+				type: "number",
+			},
+			minItems: 3,
+			maxItems: 3,
+		},
 		season: {
 			type: "integer",
 		},


### PR DESCRIPTION
## Summary
Player pages can now explain why a player's ratings moved, not just by how much. Each season's development stores a compact 3-component breakdown (age curve / coaching / random variance), and the ratings overview shows it as a one-line "Development:" readout. Simulation behavior is unchanged - the components are accumulated alongside the existing math without touching any random draw order.

## Why this matters
Progression opacity is the most-upvoted current complaint on the subreddit:

| Source | Evidence | Engagement |
|--------|----------|------------|
| [r/BasketballGM](https://www.reddit.com/r/BasketballGM/comments/1tdks5r/) | "the progression system feels less 'unpredictable' and more disconnected from the actual simulation" | 65 upvotes |
| [r/BasketballGM](https://www.reddit.com/r/BasketballGM/comments/1tsfny7/) | players hunting for settings that make progression feel believable | 59 upvotes |

This addresses the complaint by making the existing system legible instead of rebalancing it (deliberately staying out of the way of the open progression-formula PRs like #320/#404/#405).

## Demo
Simulated Demo:

![demo](https://raw.githubusercontent.com/mvanhorn/zengm/evidence-assets/dev-breakdown-demo.gif)

([GIF mirror](https://files.catbox.moe/md2adm.gif))

## Changes
- Components are accumulated inside `developSeason` for all 4 sports and stored as `progBreakdown?: [age, coaching, random]` (rounded, one array per season) on the ratings row - an optional field, so old leagues and league files are unaffected.
- To avoid leaking exact development info in scouting-fuzz leagues, the breakdown is omitted whenever fuzz is effectively active; it shows in God Mode and multi-team leagues, mirroring the `fuzzRating` rules.
- When basketball `realPlayerDeterminism` blends ratings toward historical values, the stored components are scaled by the simulated share so they still sum to the applied change.

## Testing
- New vitest unit test asserts the three components sum (within rounding) to the applied rating delta and that rating values are byte-identical to the pre-change path.
- `node --run lint` and the full `node --run test` suite pass.
