### PR TITLE
Generate playoff series games up front and add god mode force series winner

### DIFF
--- a/src/ui/views/DailySchedule.tsx
+++ b/src/ui/views/DailySchedule.tsx
@@ -3,7 +3,7 @@ import useTitleBar from "../hooks/useTitleBar.tsx";
 import type { View } from "../../common/types.ts";
 import { toWorker } from "../util/toWorker.ts";
 import { useLocal } from "../util/local.ts";
-import { DAILY_SCHEDULE } from "../../common/constants.ts";
+import { DAILY_SCHEDULE, PHASE } from "../../common/constants.ts";
 import { NoGamesMessage } from "./GameLog.tsx";
 import allowForceTie from "../../common/allowForceTie.ts";
 import { ForceWin } from "../components/ForceWin.tsx";
@@ -95,7 +95,9 @@ const DailySchedule = ({
 							<div className="d-flex flex-wrap" style={{ gap: "1rem 2rem" }}>
 								{upcoming.map((game) => {
 									const actions =
-										isToday && !tradeDeadline
+										isToday &&
+										!tradeDeadline &&
+										(phase !== PHASE.PLAYOFFS || game.canLiveSim)
 											? [
 													{
 														disabled: gameSimInProgress,

--- a/src/ui/views/Playoffs.tsx
+++ b/src/ui/views/Playoffs.tsx
@@ -3,18 +3,93 @@ import useTitleBar from "../hooks/useTitleBar.tsx";
 import type { View } from "../../common/types.ts";
 import { helpers } from "../util/helpers.ts";
 import { toWorker } from "../util/toWorker.ts";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import clsx from "clsx";
 import { range } from "../../common/utils.ts";
 import { PlayoffMatchup } from "../components/PlayoffMatchup.tsx";
 import { useLocal } from "../util/local.ts";
 
 type TeamToEdit = View<"playoffs">["teamsToEdit"][number];
+type ForceSeriesInfo = NonNullable<
+	View<"playoffs">["forceSeries"][number][number]
+>;
+type PlayoffSeriesMatchup = View<"playoffs">["series"][number][number];
+
+const ForceSeriesWinner = ({
+	forceSeriesInfo,
+	matchupIndex,
+	round,
+	series,
+}: {
+	forceSeriesInfo?: ForceSeriesInfo;
+	matchupIndex: number;
+	round: number;
+	series?: PlayoffSeriesMatchup;
+}) => {
+	const [state, setState] = useState<"saving" | "saved" | "error">();
+	const [forceWin, setForceWin] = useState(forceSeriesInfo?.forceWin);
+
+	useEffect(() => {
+		setForceWin(forceSeriesInfo?.forceWin);
+	}, [forceSeriesInfo?.forceWin]);
+
+	if (!forceSeriesInfo || !series?.away) {
+		return null;
+	}
+
+	const id = `force-series-${round}-${matchupIndex}`;
+
+	return (
+		<div className="mt-1 d-flex align-items-center">
+			<label className="me-1 small text-body-secondary" htmlFor={id}>
+				Force
+			</label>
+			<select
+				className="form-select form-select-sm god-mode"
+				disabled={state === "saving"}
+				id={id}
+				onChange={async (event) => {
+					const newForceWin =
+						event.target.value === ""
+							? undefined
+							: Number.parseInt(event.target.value);
+					setForceWin(newForceWin);
+					setState("saving");
+
+					try {
+						await toWorker("main", "setForceWinSeries", {
+							matchupIndex,
+							round,
+							tid: newForceWin,
+						});
+						setState("saved");
+					} catch (error) {
+						setState("error");
+						console.error(error);
+					}
+				}}
+				title={`Force series winner (${forceSeriesInfo.numGames} remaining)`}
+				value={forceWin ?? ""}
+			>
+				<option value="">None</option>
+				<option value={series.home.tid}>{series.home.abbrev}</option>
+				<option value={series.away.tid}>{series.away.abbrev}</option>
+			</select>
+			{state === "saved" ? (
+				<span className="ms-2 glyphicon glyphicon-ok text-success" />
+			) : null}
+			{state === "error" ? (
+				<span className="ms-2 text-danger">Error</span>
+			) : null}
+		</div>
+	);
+};
 
 const Playoffs = ({
 	canEdit,
 	confNames,
 	finalMatchups,
+	forceSeries,
 	matchups,
 	numGamesPlayoffSeries,
 	numGamesToWinSeries,
@@ -164,14 +239,23 @@ const Playoffs = ({
 										maxNumCols = j + 1;
 									}
 
+									const [round, matchupIndex] = m.matchup;
+									const playoffSeriesMatchup = series[round]![matchupIndex];
+
 									return (
 										<td key={j} rowSpan={m.rowspan} style={tdStyle}>
 											<PlayoffMatchup
-												numGamesToWinSeries={numGamesToWinSeries[m.matchup[0]]}
+												numGamesToWinSeries={numGamesToWinSeries[round]}
 												season={season}
-												series={series[m.matchup[0]]![m.matchup[1]]}
+												series={playoffSeriesMatchup}
 												userTid={userTid}
 												editing={editingInfo}
+											/>
+											<ForceSeriesWinner
+												forceSeriesInfo={forceSeries[round]?.[matchupIndex]}
+												matchupIndex={matchupIndex}
+												round={round}
+												series={playoffSeriesMatchup}
 											/>
 										</td>
 									);

--- a/src/ui/views/Schedule.tsx
+++ b/src/ui/views/Schedule.tsx
@@ -84,7 +84,8 @@ const Schedule = ({
 							const tradeDeadline =
 								game.teams[0].tid === -3 && game.teams[1].tid === -3;
 							const canWatch =
-								game.teams[0].playoffs || (canLiveSimFirstGame && i === 0);
+								game.canLiveSim ||
+								(!game.teams[0].playoffs && canLiveSimFirstGame && i === 0);
 
 							const actions =
 								canWatch && tradeDeadline

--- a/src/worker/api/actions.ts
+++ b/src/worker/api/actions.ts
@@ -159,7 +159,20 @@ const addToTradingBlock = async (
 	);
 };
 
+const oneGameActionAllowed = async (gid: number) => {
+	if (g.get("phase") !== PHASE.PLAYOFFS) {
+		return true;
+	}
+
+	const scheduleToday = await season.getSchedule(true);
+	return scheduleToday.some((game) => game.gid === gid);
+};
+
 const liveGame = async (gid: number, conditions: Conditions) => {
+	if (!(await oneGameActionAllowed(gid))) {
+		return;
+	}
+
 	await toUI(
 		"realtimeUpdate",
 		[
@@ -175,6 +188,10 @@ const liveGame = async (gid: number, conditions: Conditions) => {
 };
 
 const simGame = async (gid: number, conditions: Conditions) => {
+	if (!(await oneGameActionAllowed(gid))) {
+		return;
+	}
+
 	await game.play(1, conditions, true, gid);
 };
 

--- a/src/worker/api/index.ts
+++ b/src/worker/api/index.ts
@@ -4371,7 +4371,7 @@ const updatePlayoffTeams = async (
 		await idb.cache.playoffSeries.put(playoffSeries);
 
 		// Update schedule, since games might have changed
-		await season.newSchedulePlayoffsDay();
+		await season.newSchedulePlayoffsDay({ forceRegenerateSchedule: true });
 
 		// Update teamSeasons, since playoffRoundsWon might need to be updated
 		const teamSeasons = await idb.cache.teamSeasons.indexGetAll(

--- a/src/worker/api/index.ts
+++ b/src/worker/api/index.ts
@@ -117,6 +117,7 @@ import {
 	orderBy,
 	range,
 } from "../../common/utils.ts";
+import { getScheduledGamesForSeries } from "../core/season/playoffSchedule.ts";
 import {
 	finalizePlayersRelativesList,
 	formatPlayerRelativesList,
@@ -3591,6 +3592,54 @@ const setForceWinAll = async ({
 	await toUI("realtimeUpdate", [["gameSim"]]);
 };
 
+const setForceWinSeries = async ({
+	matchupIndex,
+	round,
+	tid,
+}: {
+	matchupIndex: number;
+	round: number;
+	tid?: number;
+}) => {
+	const playoffSeries = await idb.cache.playoffSeries.get(g.get("season"));
+	if (!playoffSeries) {
+		throw new Error("Playoff series not found");
+	}
+	if (playoffSeries.currentRound !== round || round < 0) {
+		throw new Error("Can only force current-round playoff series");
+	}
+
+	const matchup = playoffSeries.series[round]?.[matchupIndex];
+	if (!matchup?.away) {
+		throw new Error("Playoff series matchup not found");
+	}
+	if (
+		tid !== undefined &&
+		tid !== matchup.home.tid &&
+		tid !== matchup.away.tid
+	) {
+		throw new Error("Invalid team");
+	}
+
+	const schedule = await idb.cache.schedule.getAll();
+	const games = getScheduledGamesForSeries(
+		schedule,
+		matchup.home.tid,
+		matchup.away.tid,
+	);
+
+	for (const game of games) {
+		if (tid === undefined) {
+			delete game.forceWin;
+		} else {
+			game.forceWin = tid;
+		}
+		await idb.cache.schedule.put(game);
+	}
+
+	await toUI("realtimeUpdate", [["gameSim"]]);
+};
+
 const setGOATFormula = async ({
 	formula,
 	type,
@@ -5267,6 +5316,7 @@ export default {
 		runBefore,
 		setForceWin,
 		setForceWinAll,
+		setForceWinSeries,
 		setGOATFormula,
 		setLocal,
 		setNote,

--- a/src/worker/core/game/updatePlayoffSeries.ts
+++ b/src/worker/core/game/updatePlayoffSeries.ts
@@ -5,6 +5,7 @@ import season from "../season/index.ts";
 import { findSeries } from "./writeGameStats.ts";
 import getWinner from "../../../common/getWinner.ts";
 import formatScoreWithShootout from "../../../common/formatScoreWithShootout.ts";
+import { deleteScheduledGamesForCompletedSeries } from "../season/playoffSchedule.ts";
 
 const updatePlayoffSeries = async (
 	results: GameResults,
@@ -238,6 +239,7 @@ const updatePlayoffSeries = async (
 	}
 
 	await idb.cache.playoffSeries.put(playoffSeries);
+	await deleteScheduledGamesForCompletedSeries(playoffSeries);
 };
 
 export default updatePlayoffSeries;

--- a/src/worker/core/season/genPlayoffSeries.test.ts
+++ b/src/worker/core/season/genPlayoffSeries.test.ts
@@ -1,7 +1,24 @@
-import { afterAll, assert, beforeAll, test } from "vitest";
-import { g } from "../../util/index.ts";
-import { resetG } from "../../../test/helpers.ts";
+import {
+	afterAll,
+	assert,
+	beforeAll,
+	beforeEach,
+	describe,
+	test,
+} from "vitest";
+import { g, helpers } from "../../util/index.ts";
+import { resetCache, resetG } from "../../../test/helpers.ts";
 import { makeMatchups } from "./genPlayoffSeries.ts";
+import { idb } from "../../db/index.ts";
+import { PHASE } from "../../../common/constants.ts";
+import type { PlayoffSeries } from "../../../common/types.ts";
+import newSchedulePlayoffsDay from "./newSchedulePlayoffsDay.ts";
+import {
+	betterSeedHome,
+	deleteScheduledGamesForCompletedSeries,
+} from "./playoffSchedule.ts";
+import api from "../../api/index.ts";
+import team from "../team/index.ts";
 
 const makeMatchupsWrapper = (
 	teams: { tid: number; cid: number }[],
@@ -385,4 +402,131 @@ test("handle 16 teams", () => {
 			assert.strictEqual(matchup[1], away.tid);
 		}
 	}
+});
+
+const genTeam = (tid: number, seed: number) => ({
+	cid: 0,
+	seed,
+	tid,
+	won: 0,
+});
+
+const setupPlayoffScheduleTest = async (
+	numGamesPlayoffSeries: number,
+): Promise<PlayoffSeries> => {
+	resetG();
+	g.setWithoutSavingToDB("allStarGame", null);
+	g.setWithoutSavingToDB("godMode", true);
+	g.setWithoutSavingToDB("numGamesPlayoffSeries", [numGamesPlayoffSeries]);
+	g.setWithoutSavingToDB("phase", PHASE.PLAYOFFS);
+	const teamsDefault = helpers.getTeamsDefault().slice(0, 4);
+	await resetCache({
+		teams: teamsDefault.map(team.generate),
+		teamSeasons: teamsDefault.map((t) => team.genSeasonRow(t)),
+	});
+
+	const playoffSeries: PlayoffSeries = {
+		currentRound: 0,
+		season: g.get("season"),
+		series: [
+			[
+				{
+					home: genTeam(0, 1),
+					away: genTeam(1, 4),
+				},
+				{
+					home: genTeam(2, 2),
+					away: genTeam(3, 3),
+				},
+			],
+		],
+	};
+	await idb.cache.playoffSeries.put(playoffSeries);
+
+	return playoffSeries;
+};
+
+describe("newSchedulePlayoffsDay", () => {
+	beforeEach(async () => {
+		await resetCache();
+	});
+
+	for (const numGamesPlayoffSeries of [4, 5, 7]) {
+		test(`pre-generates all games in a ${numGamesPlayoffSeries}-game series`, async () => {
+			await setupPlayoffScheduleTest(numGamesPlayoffSeries);
+
+			const playoffsOver = await newSchedulePlayoffsDay();
+			assert.strictEqual(playoffsOver, false);
+
+			const schedule = await idb.cache.schedule.getAll();
+			assert.strictEqual(schedule.length, 2 * numGamesPlayoffSeries);
+
+			for (let gameNum = 0; gameNum < numGamesPlayoffSeries; gameNum++) {
+				const day = gameNum + 1;
+				const betterHome = betterSeedHome(numGamesPlayoffSeries, gameNum);
+
+				for (const seriesIndex of [0, 1]) {
+					const game = schedule[2 * gameNum + seriesIndex]!;
+					assert.strictEqual(game.day, day);
+
+					const homeTid = seriesIndex === 0 ? 0 : 2;
+					const awayTid = seriesIndex === 0 ? 1 : 3;
+					assert.strictEqual(game.homeTid, betterHome ? homeTid : awayTid);
+					assert.strictEqual(game.awayTid, betterHome ? awayTid : homeTid);
+				}
+			}
+		});
+	}
+
+	test("deletes unplayed surplus games after a series is decided", async () => {
+		const playoffSeries = await setupPlayoffScheduleTest(7);
+		await newSchedulePlayoffsDay();
+
+		const schedule = await idb.cache.schedule.getAll();
+		for (const game of schedule.slice(0, 8)) {
+			await idb.cache.schedule.delete(game.gid);
+		}
+
+		playoffSeries.series[0]![0]!.home.won = 4;
+		playoffSeries.series[0]![1]!.away!.won = 4;
+		await idb.cache.playoffSeries.put(playoffSeries);
+
+		const gidsDeleted =
+			await deleteScheduledGamesForCompletedSeries(playoffSeries);
+		assert.strictEqual(gidsDeleted.length, 6);
+		assert.strictEqual((await idb.cache.schedule.getAll()).length, 0);
+	});
+
+	test("sets and clears forceWin for all remaining games in a series", async () => {
+		await setupPlayoffScheduleTest(5);
+		await newSchedulePlayoffsDay();
+
+		await api.main.setForceWinSeries({
+			matchupIndex: 0,
+			round: 0,
+			tid: 1,
+		});
+
+		let schedule = await idb.cache.schedule.getAll();
+		for (const game of schedule.filter(
+			(game) => game.homeTid === 0 || game.awayTid === 0,
+		)) {
+			assert.strictEqual(game.forceWin, 1);
+		}
+		for (const game of schedule.filter(
+			(game) => game.homeTid === 2 || game.awayTid === 2,
+		)) {
+			assert.strictEqual(game.forceWin, undefined);
+		}
+
+		await api.main.setForceWinSeries({
+			matchupIndex: 0,
+			round: 0,
+		});
+
+		schedule = await idb.cache.schedule.getAll();
+		for (const game of schedule) {
+			assert.strictEqual(game.forceWin, undefined);
+		}
+	});
 });

--- a/src/worker/core/season/genPlayoffSeries.test.ts
+++ b/src/worker/core/season/genPlayoffSeries.test.ts
@@ -9,6 +9,7 @@ import {
 import { g, helpers } from "../../util/index.ts";
 import { resetCache, resetG } from "../../../test/helpers.ts";
 import { makeMatchups } from "./genPlayoffSeries.ts";
+import getSchedule from "./getSchedule.ts";
 import { idb } from "../../db/index.ts";
 import { PHASE } from "../../../common/constants.ts";
 import type { PlayoffSeries } from "../../../common/types.ts";
@@ -17,6 +18,7 @@ import {
 	betterSeedHome,
 	deleteScheduledGamesForCompletedSeries,
 } from "./playoffSchedule.ts";
+import { getUpcoming } from "../../views/schedule.ts";
 import api from "../../api/index.ts";
 import team from "../team/index.ts";
 
@@ -478,6 +480,30 @@ describe("newSchedulePlayoffsDay", () => {
 			}
 		});
 	}
+
+	test("marks only current-day playoff games as live-simmable", async () => {
+		await setupPlayoffScheduleTest(7);
+		await newSchedulePlayoffsDay();
+
+		const scheduleToday = await getSchedule(true);
+		const currentDayGids = new Set(scheduleToday.map((game) => game.gid));
+
+		const upcoming = await getUpcoming({});
+
+		assert.strictEqual(upcoming.length, 14);
+		assert.deepStrictEqual(
+			upcoming
+				.filter((game) => game.canLiveSim)
+				.map((game) => game.gid),
+			[...currentDayGids],
+		);
+		assert.strictEqual(
+			upcoming
+				.filter((game) => !currentDayGids.has(game.gid))
+				.every((game) => !game.canLiveSim),
+			true,
+		);
+	});
 
 	test("regenerates current-round schedule after playoff team edits", async () => {
 		await setupPlayoffScheduleTest(7);

--- a/src/worker/core/season/genPlayoffSeries.test.ts
+++ b/src/worker/core/season/genPlayoffSeries.test.ts
@@ -419,6 +419,7 @@ const setupPlayoffScheduleTest = async (
 	g.setWithoutSavingToDB("godMode", true);
 	g.setWithoutSavingToDB("numGamesPlayoffSeries", [numGamesPlayoffSeries]);
 	g.setWithoutSavingToDB("phase", PHASE.PLAYOFFS);
+	g.setWithoutSavingToDB("playoffsByConf", false);
 	const teamsDefault = helpers.getTeamsDefault().slice(0, 4);
 	await resetCache({
 		teams: teamsDefault.map(team.generate),
@@ -477,6 +478,71 @@ describe("newSchedulePlayoffsDay", () => {
 			}
 		});
 	}
+
+	test("regenerates current-round schedule after playoff team edits", async () => {
+		await setupPlayoffScheduleTest(7);
+		await newSchedulePlayoffsDay();
+
+		await api.main.updatePlayoffTeams([
+			{ cid: 0, seed: 1, tid: 0 },
+			{ cid: 0, seed: 2, tid: 2 },
+			{ cid: 0, seed: 3, tid: 1 },
+			{ cid: 0, seed: 4, tid: 3 },
+		]);
+
+		const playoffSeries = await idb.cache.playoffSeries.get(g.get("season"));
+		assert.strictEqual(playoffSeries!.series[0]![0]!.away!.tid, 3);
+		assert.strictEqual(playoffSeries!.series[0]![1]!.away!.tid, 1);
+
+		const schedule = await idb.cache.schedule.getAll();
+		assert.strictEqual(schedule.length, 14);
+
+		for (let gameNum = 0; gameNum < 7; gameNum++) {
+			const betterHome = betterSeedHome(7, gameNum);
+			const expectedTids = [
+				betterHome ? [0, 3] : [3, 0],
+				betterHome ? [2, 1] : [1, 2],
+			];
+
+			for (const seriesIndex of [0, 1]) {
+				const game = schedule[2 * gameNum + seriesIndex]!;
+				assert.strictEqual(game.homeTid, expectedTids[seriesIndex]![0]);
+				assert.strictEqual(game.awayTid, expectedTids[seriesIndex]![1]);
+			}
+		}
+	});
+
+	test("resumes generated playoff schedule from games already played", async () => {
+		const playoffSeries = await setupPlayoffScheduleTest(7);
+		playoffSeries.series[0]![0]!.home.won = 2;
+		playoffSeries.series[0]![0]!.away!.won = 1;
+		playoffSeries.series[0]![1]!.home.won = 1;
+		playoffSeries.series[0]![1]!.away!.won = 1;
+		await idb.cache.playoffSeries.put(playoffSeries);
+
+		await newSchedulePlayoffsDay();
+
+		const schedule = await idb.cache.schedule.getAll();
+		assert.strictEqual(schedule.length, 9);
+
+		const expectedTids: [number, number][] = [];
+		for (let gameNum = 0; gameNum < 7; gameNum++) {
+			const betterHome = betterSeedHome(7, gameNum);
+
+			if (gameNum >= 3) {
+				expectedTids.push(betterHome ? [0, 1] : [1, 0]);
+			}
+
+			if (gameNum >= 2) {
+				expectedTids.push(betterHome ? [2, 3] : [3, 2]);
+			}
+		}
+
+		for (const [i, expected] of expectedTids.entries()) {
+			assert.strictEqual(schedule[i]!.homeTid, expected[0]);
+			assert.strictEqual(schedule[i]!.awayTid, expected[1]);
+		}
+	});
 
 	test("deletes unplayed surplus games after a series is decided", async () => {
 		const playoffSeries = await setupPlayoffScheduleTest(7);

--- a/src/worker/core/season/newSchedulePlayoffsDay.ts
+++ b/src/worker/core/season/newSchedulePlayoffsDay.ts
@@ -49,7 +49,11 @@ const getTeamsForOrderTeams = async () => {
  * @memberOf core.season
  * @return {Promise.boolean} Resolves to true if the playoffs are over. Otherwise, false.
  */
-const newSchedulePlayoffsDay = async (): Promise<boolean> => {
+const newSchedulePlayoffsDay = async ({
+	forceRegenerateSchedule = false,
+}: {
+	forceRegenerateSchedule?: boolean;
+} = {}): Promise<boolean> => {
 	const playoffSeries = await idb.cache.playoffSeries.get(g.get("season"));
 	if (!playoffSeries) {
 		throw new Error("No playoff series");
@@ -132,14 +136,22 @@ const newSchedulePlayoffsDay = async (): Promise<boolean> => {
 	}
 
 	if (activeSeries.length > 0) {
-		for (const { away, home } of activeSeries) {
-			if (getScheduledGamesForSeries(schedule, home.tid, away.tid).length > 0) {
-				return false;
+		if (!forceRegenerateSchedule) {
+			for (const { away, home } of activeSeries) {
+				if (
+					getScheduledGamesForSeries(schedule, home.tid, away.tid).length > 0
+				) {
+					return false;
+				}
 			}
 		}
 
 		for (let gameNum = 0; gameNum < numGamesPlayoffSeries; gameNum++) {
 			for (const { away, home } of activeSeries) {
+				if (gameNum < home.won + away.won) {
+					continue;
+				}
+
 				// Make sure to set home/away teams correctly! Home for the lower seed is 1st, 2nd, 5th, and 7th games.
 				if (betterSeedHome(numGamesPlayoffSeries, gameNum)) {
 					tids.push([home.tid, away.tid]);
@@ -164,6 +176,10 @@ const newSchedulePlayoffsDay = async (): Promise<boolean> => {
 			if (!allStar?.score) {
 				tids.unshift([-1, -2]);
 			}
+		}
+
+		if (forceRegenerateSchedule) {
+			await idb.cache.schedule.clear();
 		}
 
 		await setSchedule(tids);

--- a/src/worker/core/season/newSchedulePlayoffsDay.ts
+++ b/src/worker/core/season/newSchedulePlayoffsDay.ts
@@ -6,32 +6,12 @@ import { season } from "../index.ts";
 import { isSport } from "../../../common/sportFunctions.ts";
 import { chunk, groupByUnique } from "../../../common/utils.ts";
 import { orderTeams } from "../../util/orderTeams.ts";
-
-// Play 2 home (true) then 2 away (false) and repeat, but ensure that the better team always gets the last game.
-const betterSeedHome = (numGamesPlayoffSeries: number, gameNum: number) => {
-	// For series lengths like 3, 7, 11, 15, etc., special case last 3 games to ensure the home team always gets the last game
-	const needsSpecialEnding = (numGamesPlayoffSeries + 1) % 4 === 0;
-
-	if (needsSpecialEnding) {
-		// Special case for last 3 games
-		if (gameNum >= numGamesPlayoffSeries - 3) {
-			return (
-				gameNum === numGamesPlayoffSeries - 3 ||
-				gameNum === numGamesPlayoffSeries - 1
-			);
-		}
-	}
-
-	const num = Math.floor(gameNum / 2);
-	return num % 2 === 0;
-};
-
-const seriesIsNotOver = (
-	home: PlayoffSeriesTeam,
-	away: PlayoffSeriesTeam | undefined,
-	numGamesToWin: number,
-): away is PlayoffSeriesTeam =>
-	!!(away && home.won < numGamesToWin && away.won < numGamesToWin);
+import {
+	betterSeedHome,
+	deleteScheduledGamesForCompletedSeries,
+	getScheduledGamesForSeries,
+	seriesIsNotOver,
+} from "./playoffSchedule.ts";
 
 const getTeamsForOrderTeams = async () => {
 	return idb.getCopies.teamsPlus(
@@ -123,6 +103,7 @@ const newSchedulePlayoffsDay = async (): Promise<boolean> => {
 		} else {
 			// playIn is over, so proceed to next round
 			playoffSeries.currentRound = 0;
+			await idb.cache.playoffSeries.put(playoffSeries);
 		}
 	}
 
@@ -134,40 +115,37 @@ const newSchedulePlayoffsDay = async (): Promise<boolean> => {
 
 	const rnd = playoffSeries.currentRound;
 	const tids: [number, number][] = [];
-	const numGamesToWin = helpers.numGamesToWinSeries(
-		g.get("numGamesPlayoffSeries", "current")[rnd],
-	);
+	const numGamesPlayoffSeries = g.get("numGamesPlayoffSeries", "current")[rnd]!;
+	const numGamesToWin = helpers.numGamesToWinSeries(numGamesPlayoffSeries);
 
-	let minGamesPlayedThisRound = Infinity;
+	await deleteScheduledGamesForCompletedSeries(playoffSeries);
+
+	const schedule = await idb.cache.schedule.getAll();
+	const activeSeries: {
+		home: PlayoffSeriesTeam;
+		away: PlayoffSeriesTeam;
+	}[] = [];
 	for (const { away, home } of series[rnd]!) {
 		if (seriesIsNotOver(home, away, numGamesToWin)) {
-			const numGames = home.won + away.won;
-			if (numGames < minGamesPlayedThisRound) {
-				minGamesPlayedThisRound = numGames;
-			}
+			activeSeries.push({ away, home });
 		}
 	}
 
-	// Try to schedule games if there are active series
-	for (const { away, home } of series[rnd]!) {
-		if (seriesIsNotOver(home, away, numGamesToWin)) {
-			const numGames = home.won + away.won;
-
-			// Because live game sim is an individual game now, not a whole day, need to check if some series are ahead of others and therefore should not get a game today.
-			if (numGames > minGamesPlayedThisRound) {
-				continue;
+	if (activeSeries.length > 0) {
+		for (const { away, home } of activeSeries) {
+			if (getScheduledGamesForSeries(schedule, home.tid, away.tid).length > 0) {
+				return false;
 			}
+		}
 
-			// Make sure to set home/away teams correctly! Home for the lower seed is 1st, 2nd, 5th, and 7th games.
-			if (
-				betterSeedHome(
-					g.get("numGamesPlayoffSeries", "current")[rnd]!,
-					numGames,
-				)
-			) {
-				tids.push([home.tid, away.tid]);
-			} else {
-				tids.push([away.tid, home.tid]);
+		for (let gameNum = 0; gameNum < numGamesPlayoffSeries; gameNum++) {
+			for (const { away, home } of activeSeries) {
+				// Make sure to set home/away teams correctly! Home for the lower seed is 1st, 2nd, 5th, and 7th games.
+				if (betterSeedHome(numGamesPlayoffSeries, gameNum)) {
+					tids.push([home.tid, away.tid]);
+				} else {
+					tids.push([away.tid, home.tid]);
+				}
 			}
 		}
 	}

--- a/src/worker/core/season/playoffSchedule.ts
+++ b/src/worker/core/season/playoffSchedule.ts
@@ -1,0 +1,89 @@
+import { idb } from "../../db/index.ts";
+import { g, helpers } from "../../util/index.ts";
+import type {
+	PlayoffSeries,
+	PlayoffSeriesTeam,
+	ScheduleGame,
+} from "../../../common/types.ts";
+
+// Play 2 home (true) then 2 away (false) and repeat, but ensure that the better team always gets the last game.
+export const betterSeedHome = (
+	numGamesPlayoffSeries: number,
+	gameNum: number,
+) => {
+	// For series lengths like 3, 7, 11, 15, etc., special case last 3 games to ensure the home team always gets the last game
+	const needsSpecialEnding = (numGamesPlayoffSeries + 1) % 4 === 0;
+
+	if (needsSpecialEnding) {
+		// Special case for last 3 games
+		if (gameNum >= numGamesPlayoffSeries - 3) {
+			return (
+				gameNum === numGamesPlayoffSeries - 3 ||
+				gameNum === numGamesPlayoffSeries - 1
+			);
+		}
+	}
+
+	const num = Math.floor(gameNum / 2);
+	return num % 2 === 0;
+};
+
+export const seriesIsNotOver = (
+	home: PlayoffSeriesTeam,
+	away: PlayoffSeriesTeam | undefined,
+	numGamesToWin: number,
+): away is PlayoffSeriesTeam =>
+	!!(away && home.won < numGamesToWin && away.won < numGamesToWin);
+
+export const getSeriesTidKey = (tid0: number, tid1: number) =>
+	tid0 < tid1 ? `${tid0},${tid1}` : `${tid1},${tid0}`;
+
+export const getScheduledGamesForSeries = (
+	schedule: ScheduleGame[],
+	tid0: number,
+	tid1: number,
+) => {
+	const key = getSeriesTidKey(tid0, tid1);
+	return schedule.filter(
+		(game) => getSeriesTidKey(game.homeTid, game.awayTid) === key,
+	);
+};
+
+export const deleteScheduledGamesForCompletedSeries = async (
+	playoffSeries: PlayoffSeries,
+) => {
+	if (playoffSeries.currentRound < 0) {
+		return [];
+	}
+
+	const roundSeries = playoffSeries.series[playoffSeries.currentRound];
+	if (!roundSeries) {
+		return [];
+	}
+
+	const numGamesToWin = helpers.numGamesToWinSeries(
+		g.get("numGamesPlayoffSeries", "current")[playoffSeries.currentRound],
+	);
+
+	const completedSeriesKeys = new Set<string>();
+	for (const { away, home } of roundSeries) {
+		if (away && (home.won >= numGamesToWin || away.won >= numGamesToWin)) {
+			completedSeriesKeys.add(getSeriesTidKey(home.tid, away.tid));
+		}
+	}
+
+	if (completedSeriesKeys.size === 0) {
+		return [];
+	}
+
+	const gidsDeleted = [];
+	const schedule = await idb.cache.schedule.getAll();
+	for (const game of schedule) {
+		if (completedSeriesKeys.has(getSeriesTidKey(game.homeTid, game.awayTid))) {
+			gidsDeleted.push(game.gid);
+			await idb.cache.schedule.delete(game.gid);
+		}
+	}
+
+	return gidsDeleted;
+};

--- a/src/worker/views/playoffs.ts
+++ b/src/worker/views/playoffs.ts
@@ -7,6 +7,10 @@ import type {
 	PlayoffSeries,
 } from "../../common/types.ts";
 import { orderTeams } from "../util/orderTeams.ts";
+import {
+	getScheduledGamesForSeries,
+	seriesIsNotOver,
+} from "../core/season/playoffSchedule.ts";
 
 type SeriesTeam = {
 	abbrev: string;
@@ -52,6 +56,11 @@ type TeamToEdit = {
 	record: string;
 };
 
+type ForceSeriesInfo = {
+	forceWin?: number;
+	numGames: number;
+};
+
 const updatePlayoffs = async (
 	inputs: ViewInput<"playoffs">,
 	updateEvents: UpdateEvents,
@@ -65,6 +74,7 @@ const updatePlayoffs = async (
 				matchup: [number, number];
 				rowspan: number;
 			}[][];
+			forceSeries: (ForceSeriesInfo | undefined)[][];
 			numGamesPlayoffSeries: number[];
 			numGamesToWinSeries: number[];
 			playIns: PlayIns;
@@ -155,6 +165,48 @@ const updatePlayoffs = async (
 		const numGamesPlayoffSeries = g.get("numGamesPlayoffSeries", inputs.season);
 
 		const playoffsByConf = await season.getPlayoffsByConf(inputs.season);
+
+		const forceSeries: (ForceSeriesInfo | undefined)[][] = series.map((row) =>
+			row.map(() => undefined),
+		);
+		if (
+			finalMatchups &&
+			g.get("godMode") &&
+			inputs.season === g.get("season") &&
+			playoffSeries &&
+			playoffSeries.currentRound >= 0
+		) {
+			const round = playoffSeries.currentRound;
+			const numGamesToWin = helpers.numGamesToWinSeries(
+				numGamesPlayoffSeries[round],
+			);
+			const schedule = await idb.cache.schedule.getAll();
+			for (const [i, matchup] of series[round]!.entries()) {
+				if (
+					matchup.away &&
+					seriesIsNotOver(matchup.home, matchup.away, numGamesToWin)
+				) {
+					const games = getScheduledGamesForSeries(
+						schedule,
+						matchup.home.tid,
+						matchup.away.tid,
+					);
+
+					if (games.length > 0) {
+						const forceWins = new Set(games.map((game) => game.forceWin));
+						const forceWin =
+							forceWins.size === 1
+								? forceWins.values().next().value
+								: undefined;
+
+						forceSeries[round]![i] = {
+							forceWin: typeof forceWin === "number" ? forceWin : undefined,
+							numGames: games.length,
+						};
+					}
+				}
+			}
+		}
 
 		let canEdit =
 			finalMatchups && g.get("godMode") && inputs.season === g.get("season");
@@ -252,6 +304,7 @@ const updatePlayoffs = async (
 			canEdit,
 			confNames,
 			finalMatchups,
+			forceSeries,
 			matchups,
 			numGamesPlayoffSeries,
 			numGamesToWinSeries: numGamesPlayoffSeries.map(

--- a/src/worker/views/schedule.ts
+++ b/src/worker/views/schedule.ts
@@ -175,6 +175,7 @@ export const getUpcoming = async ({
 	};
 
 	const upcoming: {
+		canLiveSim: boolean;
 		finals?: boolean;
 		forceWin?: number | "tie";
 		gid: number;
@@ -183,6 +184,7 @@ export const getUpcoming = async ({
 	}[] = filteredSchedule.map(
 		({ awayTid, day, finals, forceWin, gid, homeTid }) => {
 			return {
+				canLiveSim: false,
 				finals,
 				forceWin,
 				gid,
@@ -191,6 +193,14 @@ export const getUpcoming = async ({
 			};
 		},
 	);
+
+	if (g.get("phase") === PHASE.PLAYOFFS) {
+		const scheduleToday = await season.getSchedule(true);
+		const canLiveSimGids = new Set(scheduleToday.map((game) => game.gid));
+		for (const game of upcoming) {
+			game.canLiveSim = canLiveSimGids.has(game.gid);
+		}
+	}
 
 	return upcoming;
 };


### PR DESCRIPTION
## Summary
Playoff series games are now generated up front when a round starts, instead of one game at a time - and God Mode gets a per-series "force winner" control that sets forceWin on every remaining game of that series. This is the approach you described in #503.

## Why this matters
From your comment on #503:

> "One thing I do want to do is generate the entire playoff series games up front, rather than one at a time. Then you could force win/loss for the whole series at once. I just haven't gotten around to it yet."

Forcing future rounds is left out, matching your "maybe less important" read.

## Demo
Simulated Demo:

![demo](https://raw.githubusercontent.com/mvanhorn/zengm/evidence-assets/playoff-series-demo.gif)

([GIF mirror](https://files.catbox.moe/tdk2bt.gif))

## Changes
- `newSchedulePlayoffsDay` generates the full series schedule at series start (per-sport home-court patterns); sims consume the pre-generated games in order, and surplus unplayed games are removed from the schedule store once a series is decided.
- Leagues saved mid-playoffs before this change resume correctly: generation picks up from `home.won + away.won`, so home/away slots stay aligned.
- God Mode bracket edits (`updatePlayoffTeams`) regenerate the unplayed games for affected series instead of simming stale matchups.
- Playoffs page exposes remaining games per undecided series with the force-winner control (God Mode only), wired through the existing per-game forceWin path.

## Testing
- Extended `genPlayoffSeries.test.ts` plus new tests for 4/5/7-game series pre-generation, surplus cleanup, forced series winners, mid-series resume, and bracket-edit regeneration.
- `node --run lint` and full `node --run test` pass. All 4 sports, including play-in and byes.

Fixes #503
