### PR TITLE
Add minimal coaching staff (head coach + assistants)

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -29,7 +29,7 @@ export const DRAFT_BY_TEAM_OVR = bySport({
 	hockey: true,
 });
 
-export const LEAGUE_DATABASE_VERSION = 72;
+export const LEAGUE_DATABASE_VERSION = 73;
 
 export const NO_LOTTERY_DRAFT_TYPES = new Set<DraftType>([
 	"freeAgents",

--- a/src/common/staff.ts
+++ b/src/common/staff.ts
@@ -1,0 +1,120 @@
+import { helpers } from "./helpers.ts";
+import { bySport } from "./sportFunctions.ts";
+
+export const COACH_SLOTS = ["headCoach", "assistant1", "assistant2"] as const;
+export type CoachSlot = (typeof COACH_SLOTS)[number];
+
+export const COACH_SLOT_NAMES: Record<CoachSlot, string> = {
+	headCoach: "Head Coach",
+	assistant1: "Assistant 1",
+	assistant2: "Assistant 2",
+};
+
+export const COACH_SPECIALTIES = bySport({
+	baseball: ["hitting", "pitching", "fielding"],
+	basketball: ["perimeter", "interior", "shooting", "defense"],
+	football: ["offense", "defense", "specialTeams"],
+	hockey: ["offense", "defense", "goaltending"],
+} as const);
+
+export type CoachSpecialty = (typeof COACH_SPECIALTIES)[number];
+
+export const COACH_SPECIALTY_NAMES: Record<CoachSpecialty, string> = {
+	defense: "Defense",
+	fielding: "Fielding",
+	goaltending: "Goaltending",
+	hitting: "Hitting",
+	interior: "Interior",
+	offense: "Offense",
+	perimeter: "Perimeter",
+	pitching: "Pitching",
+	shooting: "Shooting",
+	specialTeams: "Special Teams",
+};
+
+const COACH_SPECIALTY_RATINGS = bySport<
+	Partial<Record<CoachSpecialty, string[]>>
+>({
+	baseball: {
+		fielding: ["spd", "gnd", "fly", "thr", "cat"],
+		hitting: ["hpw", "con", "eye"],
+		pitching: ["ppw", "ctl", "mov", "endu"],
+	},
+	basketball: {
+		defense: ["diq", "drb", "stre"],
+		interior: ["stre", "dnk", "ins", "reb"],
+		perimeter: ["spd", "jmp", "drb", "pss", "oiq"],
+		shooting: ["ft", "fg", "tp"],
+	},
+	football: {
+		defense: ["pcv", "tck", "prs", "rns"],
+		offense: ["thv", "thp", "tha", "bsc", "elu", "rtr", "hnd", "rbk", "pbk"],
+		specialTeams: ["kpw", "kac", "ppw", "pac"],
+	},
+	hockey: {
+		defense: ["chk", "blk", "fcf", "diq"],
+		goaltending: ["glk"],
+		offense: ["pss", "wst", "sst", "stk", "oiq"],
+	},
+});
+
+export type CoachingEffectInput =
+	| number
+	| {
+			level: number;
+			specialties?: CoachSpecialty[];
+	  };
+
+export const getCoachingLevel = (coaching: CoachingEffectInput) =>
+	typeof coaching === "number" ? coaching : coaching.level;
+
+const SPECIALTY_BONUS_PER_COACH = 0.04;
+const MAX_SPECIALTY_BONUS = SPECIALTY_BONUS_PER_COACH * COACH_SLOTS.length;
+
+export const getCoachSpecialtyBonus = (
+	coaching: CoachingEffectInput,
+	ratingKey: string,
+) => {
+	if (typeof coaching === "number" || !coaching.specialties) {
+		return 0;
+	}
+
+	let matches = 0;
+	for (const specialty of coaching.specialties) {
+		if (COACH_SPECIALTY_RATINGS[specialty]?.includes(ratingKey)) {
+			matches += 1;
+		}
+	}
+
+	return Math.min(matches * SPECIALTY_BONUS_PER_COACH, MAX_SPECIALTY_BONUS);
+};
+
+export const applyCoachSpecialtyChange = (
+	change: number,
+	coaching: CoachingEffectInput,
+	ratingKey: string,
+) => {
+	const bonus = getCoachSpecialtyBonus(coaching, ratingKey);
+	if (bonus === 0 || change === 0) {
+		return change;
+	}
+
+	return change > 0 ? change * (1 + bonus) : change * (1 - bonus);
+};
+
+export const getCoachQualityGrade = (quality: number) => {
+	const bounded = helpers.bound(Math.round(quality), 1, 100);
+	if (bounded >= 90) {
+		return "A";
+	}
+	if (bounded >= 75) {
+		return "B";
+	}
+	if (bounded >= 55) {
+		return "C";
+	}
+	if (bounded >= 35) {
+		return "D";
+	}
+	return "F";
+};

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import * as z from "zod";
 import type processInputs from "../worker/api/processInputs.ts";
 import type * as views from "../worker/views/index.ts";
+import type { CoachSlot, CoachSpecialty } from "./staff.ts";
 
 // Would be nice to make .at(-1) return T but idk how, so use the `last` function instead!
 export type NonEmptyArray<T> = [T, ...T[]];
@@ -1497,6 +1498,21 @@ export type ScheduleGame = ScheduleGameWithoutKey & {
 	gid: number;
 };
 
+export type CoachWithoutKey = {
+	coachId?: number;
+	firstName: string;
+	lastName: string;
+	age: number;
+	specialty: CoachSpecialty;
+	quality: number;
+	tid: number;
+	slot?: CoachSlot;
+};
+
+export type Coach = CoachWithoutKey & {
+	coachId: number;
+};
+
 export type SortOrder = "asc" | "desc";
 
 export type SortType =
@@ -1850,6 +1866,7 @@ export type UpdateEvents = (
 	| "savedTrades"
 	| "scheduledEvents"
 	| "retiredJerseys"
+	| "staff"
 	| "team"
 	| "teamFinances"
 	| "draftLottery"

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -109,6 +109,12 @@ export const resetCache = async (
 			await idb.cache.trade.add(obj);
 		}
 	}
+
+	if (data.staff) {
+		for (const obj of data.staff) {
+			await idb.cache.staff.add(obj);
+		}
+	}
 };
 
 export const resetG = () => {

--- a/src/ui/components/MoreLinks.tsx
+++ b/src/ui/components/MoreLinks.tsx
@@ -94,6 +94,10 @@ export const MoreLinks = (
 				name: "Finances",
 			},
 			{
+				url: ["staff", `${abbrev}_${tid}`],
+				name: "Staff",
+			},
+			{
 				url:
 					season !== undefined
 						? ["game_log", `${abbrev}_${tid}`, season]

--- a/src/ui/util/menuItems.tsx
+++ b/src/ui/util/menuItems.tsx
@@ -321,6 +321,14 @@ export const menuItems: (MenuItemLink | MenuItemHeader)[] = [
 			},
 			{
 				type: "link",
+				active: (pageID) => pageID === "staff",
+				league: true,
+				commandPalette: true,
+				path: ["staff"],
+				text: "Staff",
+			},
+			{
+				type: "link",
 				active: (pageID) => pageID === "teamHistory",
 				league: true,
 				commandPalette: true,

--- a/src/ui/util/routeInfos.ts
+++ b/src/ui/util/routeInfos.ts
@@ -40,6 +40,8 @@ export const routeInfos = {
 	"/l/:lid/roster/:abbrev/:season/:playoffs": "roster",
 	"/l/:lid/schedule": "schedule",
 	"/l/:lid/schedule/:abbrev": "schedule",
+	"/l/:lid/staff": "staff",
+	"/l/:lid/staff/:abbrev": "staff",
 	"/l/:lid/team_finances": "teamFinances",
 	"/l/:lid/team_finances/:abbrev": "teamFinances",
 	"/l/:lid/team_finances/:abbrev/:show": "teamFinances",

--- a/src/ui/views/ExportLeague.tsx
+++ b/src/ui/views/ExportLeague.tsx
@@ -309,6 +309,7 @@ const getExportInfo = (
 			"seasonLeaders",
 			"savedTrades",
 			"savedTradingBlock",
+			"staff",
 		],
 		newsFeedTransactions: ["events"],
 		newsFeedOther: ["events"],

--- a/src/ui/views/Staff.tsx
+++ b/src/ui/views/Staff.tsx
@@ -1,0 +1,285 @@
+import { useState } from "react";
+import { getCols } from "../../common/getCols.ts";
+import {
+	COACH_SLOT_NAMES,
+	COACH_SLOTS,
+	COACH_SPECIALTY_NAMES,
+	getCoachQualityGrade,
+	type CoachSlot,
+} from "../../common/staff.ts";
+import type { View } from "../../common/types.ts";
+import { ActionButton } from "../components/ActionButton.tsx";
+import { DataTable } from "../components/DataTable/index.tsx";
+import type { DataTableRow } from "../components/DataTable/index.tsx";
+import { MoreLinks } from "../components/MoreLinks.tsx";
+import useTitleBar from "../hooks/useTitleBar.tsx";
+import { confirm } from "../util/confirm.tsx";
+import { useLocal } from "../util/local.ts";
+import { logEvent } from "../util/logEvent.ts";
+import { toWorker } from "../util/toWorker.ts";
+
+type Coach = View<"staff">["teamStaff"][number];
+
+const coachName = (coach: Coach) => `${coach.firstName} ${coach.lastName}`;
+
+const quality = (coachQuality: number) => {
+	const grade = getCoachQualityGrade(coachQuality);
+
+	return {
+		searchValue: `${grade} ${coachQuality}`,
+		sortValue: coachQuality,
+		value: (
+			<>
+				{grade} <span className="text-body-secondary">({coachQuality})</span>
+			</>
+		),
+	};
+};
+
+const logError = (error: unknown) => {
+	logEvent({
+		saveToDb: false,
+		text: error instanceof Error ? error.message : String(error),
+		type: "error",
+	});
+};
+
+const Staff = ({
+	abbrev,
+	availableCoaches,
+	budgetLevel,
+	developmentLevel,
+	teamName,
+	teamRegion,
+	teamStaff,
+	tid,
+}: View<"staff">) => {
+	useTitleBar({
+		title: "Staff",
+		dropdownView: "staff",
+		dropdownFields: { teams: abbrev },
+	});
+
+	const { gameSimInProgress, spectator, userTids } = useLocal([
+		"gameSimInProgress",
+		"spectator",
+		"userTids",
+	]);
+
+	const [processing, setProcessing] = useState<string>();
+	const editable = userTids.includes(tid) && !spectator && !gameSimInProgress;
+
+	const coachesBySlot = new Map<CoachSlot, Coach>();
+	for (const coach of teamStaff) {
+		if (coach.slot !== undefined) {
+			coachesBySlot.set(coach.slot, coach);
+		}
+	}
+	const openSlots = COACH_SLOTS.filter((slot) => !coachesBySlot.has(slot));
+
+	const handleHire = async (coachId: number, slot: CoachSlot) => {
+		const processingKey = `hire-${coachId}-${slot}`;
+		setProcessing(processingKey);
+		try {
+			await toWorker("main", "hireCoach", {
+				coachId,
+				slot,
+				tid,
+			});
+		} catch (error) {
+			logError(error);
+		} finally {
+			setProcessing(undefined);
+		}
+	};
+
+	const handleFire = async (coach: Coach) => {
+		const proceed = await confirm(`Fire ${coachName(coach)}?`, {
+			okText: "Fire",
+		});
+		if (!proceed) {
+			return;
+		}
+
+		const processingKey = `fire-${coach.coachId}`;
+		setProcessing(processingKey);
+		try {
+			await toWorker("main", "fireCoach", {
+				coachId: coach.coachId,
+				tid,
+			});
+		} catch (error) {
+			logError(error);
+		} finally {
+			setProcessing(undefined);
+		}
+	};
+
+	const staffCols = getCols(
+		["Slot", "Name", "Age", "Specialty", "Quality", "Action"],
+		{
+			Action: {
+				noSearch: true,
+			},
+			Name: {
+				width: "100%",
+			},
+		},
+	);
+
+	const staffRows: DataTableRow[] = COACH_SLOTS.map((slot) => {
+		const coach = coachesBySlot.get(slot);
+		if (!coach) {
+			return {
+				key: slot,
+				data: [
+					COACH_SLOT_NAMES[slot],
+					{
+						searchValue: "Vacant",
+						sortValue: "",
+						value: <span className="text-body-secondary">Vacant</span>,
+					},
+					null,
+					null,
+					null,
+					null,
+				],
+			};
+		}
+
+		return {
+			key: coach.coachId,
+			data: [
+				COACH_SLOT_NAMES[slot],
+				coachName(coach),
+				coach.age,
+				COACH_SPECIALTY_NAMES[coach.specialty],
+				quality(coach.quality),
+				editable ? (
+					<ActionButton
+						className="btn-sm"
+						processing={processing === `fire-${coach.coachId}`}
+						processingText="Firing"
+						variant="danger"
+						onClick={() => {
+							void handleFire(coach);
+						}}
+					>
+						Fire
+					</ActionButton>
+				) : null,
+			],
+		};
+	});
+
+	const availableCols = getCols(
+		["Name", "Age", "Specialty", "Quality", "Action"],
+		{
+			Action: {
+				noSearch: true,
+			},
+			Name: {
+				width: "100%",
+			},
+		},
+	);
+
+	const availableRows: DataTableRow[] = availableCoaches.map((coach) => {
+		let action = null;
+		if (editable) {
+			if (openSlots.length === 0) {
+				action = <span className="text-body-secondary">No open slots</span>;
+			} else if (coach.quality > budgetLevel) {
+				action = <span className="text-body-secondary">Budget too low</span>;
+			} else {
+				action = (
+					<div className="d-flex flex-wrap gap-1">
+						{openSlots.map((slot) => {
+							const processingKey = `hire-${coach.coachId}-${slot}`;
+							return (
+								<ActionButton
+									className="btn-sm"
+									key={slot}
+									processing={processing === processingKey}
+									processingText="Hiring"
+									variant="primary"
+									onClick={() => {
+										void handleHire(coach.coachId, slot);
+									}}
+								>
+									{COACH_SLOT_NAMES[slot]}
+								</ActionButton>
+							);
+						})}
+					</div>
+				);
+			}
+		}
+
+		return {
+			key: coach.coachId,
+			data: [
+				coachName(coach),
+				coach.age,
+				COACH_SPECIALTY_NAMES[coach.specialty],
+				quality(coach.quality),
+				action,
+			],
+		};
+	});
+
+	return (
+		<>
+			<MoreLinks type="team" page="staff" abbrev={abbrev} tid={tid} />
+
+			<div className="d-flex flex-wrap gap-4 mb-3">
+				<div>
+					<div className="text-body-secondary">Team</div>
+					<b>
+						{teamRegion} {teamName}
+					</b>
+				</div>
+				<div>
+					<div className="text-body-secondary">Coaching budget</div>
+					<b>
+						{getCoachQualityGrade(budgetLevel)}{" "}
+						<span className="text-body-secondary">({budgetLevel})</span>
+					</b>
+				</div>
+				<div>
+					<div className="text-body-secondary">Staff development</div>
+					<b>
+						{getCoachQualityGrade(developmentLevel)}{" "}
+						<span className="text-body-secondary">({developmentLevel})</span>
+					</b>
+				</div>
+			</div>
+
+			<DataTable
+				cols={staffCols}
+				defaultSort={[0, "asc"]}
+				name="StaffCurrent"
+				rows={staffRows}
+				title={<h2>Current staff</h2>}
+			/>
+
+			{availableRows.length > 0 ? (
+				<DataTable
+					cols={availableCols}
+					defaultSort={[3, "desc"]}
+					name="StaffAvailable"
+					pagination
+					rows={availableRows}
+					title={<h2>Available coaches</h2>}
+				/>
+			) : (
+				<>
+					<h2>Available coaches</h2>
+					<p>None</p>
+				</>
+			)}
+		</>
+	);
+};
+
+export default Staff;

--- a/src/ui/views/index.ts
+++ b/src/ui/views/index.ts
@@ -99,6 +99,7 @@ export { default as ScheduledEvents } from "./ScheduledEvents.tsx";
 export { default as SeasonPreview } from "./SeasonPreview.tsx";
 export { default as Settings } from "./Settings/index.tsx";
 export { default as Standings } from "./Standings.tsx";
+export { default as Staff } from "./Staff.tsx";
 export { default as TeamFinances } from "./TeamFinances/index.tsx";
 export { default as TeamGraphs } from "./TeamGraphs/index.tsx";
 export { default as TeamHistory } from "./TeamHistory/index.tsx";

--- a/src/worker/api/index.ts
+++ b/src/worker/api/index.ts
@@ -33,6 +33,7 @@ import {
 	realRosters,
 	freeAgents,
 	season,
+	staff,
 } from "../core/index.ts";
 import { idb } from "../db/index.ts";
 import {
@@ -170,6 +171,7 @@ import { recomputeLocalUITeamOvrs } from "../util/recomputeLocalUITeamOvrs.ts";
 import { initUILocalGames } from "../util/initUILocalGames.ts";
 import { ValueChangeCalculator } from "../core/team/ValueChangeCalculator.ts";
 import type { GenOrderResult } from "../core/draft/genOrder.ts";
+import type { CoachSlot } from "../../common/staff.ts";
 
 const acceptContractNegotiation = async ({
 	pid,
@@ -3910,6 +3912,45 @@ const updateBudget = async ({
 	await toUI("realtimeUpdate", [["teamFinances"]]);
 };
 
+const hireCoach = async ({
+	coachId,
+	slot,
+	tid,
+}: {
+	coachId: number;
+	slot: CoachSlot;
+	tid: number;
+}) => {
+	if (!g.get("userTids").includes(tid)) {
+		throw new Error("You do not control that team.");
+	}
+
+	await staff.hire({
+		coachId,
+		slot,
+		tid,
+	});
+	await toUI("realtimeUpdate", [["staff"]]);
+};
+
+const fireCoach = async ({
+	coachId,
+	tid,
+}: {
+	coachId: number;
+	tid: number;
+}) => {
+	if (!g.get("userTids").includes(tid)) {
+		throw new Error("You do not control that team.");
+	}
+
+	await staff.fire({
+		coachId,
+		tid,
+	});
+	await toUI("realtimeUpdate", [["staff"]]);
+};
+
 const updateDefaultSettingsOverrides = async (
 	defaultSettingsOverrides: Partial<Settings>,
 ) => {
@@ -5235,6 +5276,7 @@ export default {
 		getSavedTrade,
 		getTeamGraphStat,
 		getTradingBlockOffers,
+		hireCoach,
 		ping,
 		handleUploadedDraftClass,
 		idbCacheFlush,
@@ -5256,6 +5298,7 @@ export default {
 		expandVote,
 		relocateVote,
 		cloneLeague,
+		fireCoach,
 		removeLeague,
 		removePlayers,
 		reorderDepthDrag,

--- a/src/worker/api/leagueFileUpload.ts
+++ b/src/worker/api/leagueFileUpload.ts
@@ -46,6 +46,7 @@ export const parseJSON = () => {
 		schedule: undefined,
 		scheduledEvents: undefined,
 		seasonLeaders: undefined,
+		staff: undefined,
 		teamSeasons: undefined,
 		teamStats: undefined,
 		teams: undefined,

--- a/src/worker/api/processInputs.ts
+++ b/src/worker/api/processInputs.ts
@@ -830,6 +830,11 @@ const teamFinances = (params: Params) => {
 	return { abbrev, show, tid };
 };
 
+const staff = (params: Params) => {
+	const [tid, abbrev] = validateAbbrev(params.abbrev);
+	return { abbrev, tid };
+};
+
 const teamHistory = (params: Params) => {
 	const show = params.show ?? "10";
 	const [tid, abbrev] = validateAbbrev(params.abbrev);
@@ -1138,6 +1143,7 @@ export default {
 	schedule,
 	seasonPreview: validateSeasonOnly,
 	standings,
+	staff,
 	teamFinances,
 	teamGraphs,
 	teamHistory,

--- a/src/worker/core/index.ts
+++ b/src/worker/core/index.ts
@@ -12,5 +12,6 @@ export { default as phase } from "./phase/index.ts";
 export { default as player } from "./player/index.ts";
 export { default as realRosters } from "./realRosters/index.ts";
 export { default as season } from "./season/index.ts";
+export { default as staff } from "./staff/index.ts";
 export { default as team } from "./team/index.ts";
 export { default as trade } from "./trade/index.ts";

--- a/src/worker/core/league/createStream.ts
+++ b/src/worker/core/league/createStream.ts
@@ -6,6 +6,7 @@ import {
 	league,
 	player,
 	season,
+	staff,
 	team,
 } from "../index.ts";
 import {
@@ -1779,6 +1780,8 @@ const afterDBStream = async ({
 			}
 		}
 	}
+
+	await staff.bootstrapLeagueStaff();
 
 	await idb.cache.flush();
 	idb.cache.startAutoFlush();

--- a/src/worker/core/phase/newPhasePreseason.ts
+++ b/src/worker/core/phase/newPhasePreseason.ts
@@ -276,7 +276,9 @@ const newPhasePreseason = async (
 			await staff.autoHireByBudget(t.tid, coachingLevel);
 		}
 
-		coachingByTid[t.tid] = await staff.getDevelopmentInfo(t.tid);
+		coachingByTid[t.tid] = g.get("budget")
+			? await staff.getDevelopmentInfo(t.tid)
+			: coachingLevel;
 	}
 
 	const players = await idb.cache.players.indexGetAll("playersByTid", [

--- a/src/worker/core/phase/newPhasePreseason.ts
+++ b/src/worker/core/phase/newPhasePreseason.ts
@@ -9,6 +9,7 @@ import {
 	league,
 	player,
 	realRosters,
+	staff,
 	team,
 } from "../index.ts";
 import { idb } from "../../db/index.ts";
@@ -24,6 +25,7 @@ import { applyRealTeamInfo } from "../../../common/applyRealTeamInfo.ts";
 import { bySport, isSport } from "../../../common/sportFunctions.ts";
 import { choice, randInt, uniform } from "../../../common/random.ts";
 import { env } from "../../util/env.ts";
+import type { CoachingEffectInput } from "../../../common/staff.ts";
 
 const newPhasePreseason = async (
 	conditions: Conditions,
@@ -202,11 +204,12 @@ const newPhasePreseason = async (
 	for (const [t, popRank] of Iterator.zip([activeTeams, popRanks], {
 		mode: "strict",
 	})) {
-		if (
+		const isAITeam =
 			!g.get("userTids").includes(t.tid) ||
 			local.autoPlayUntil ||
-			g.get("spectator")
-		) {
+			g.get("spectator");
+
+		if (isAITeam) {
 			await team.resetTicketPrice(t, popRank);
 
 			// Sometimes update budget items for AI teams
@@ -247,8 +250,12 @@ const newPhasePreseason = async (
 		throw new Error("scoutingLevel should be defined");
 	}
 
-	const coachingLevels: Record<number, number> = {};
+	const coachingByTid: Record<number, CoachingEffectInput> = {};
 	for (const t of teams) {
+		if (t.disabled) {
+			continue;
+		}
+
 		const teamSeasons = await idb.getCopies.teamSeasons(
 			{
 				tid: t.tid,
@@ -256,10 +263,20 @@ const newPhasePreseason = async (
 			},
 			"noCopyCache",
 		);
-		coachingLevels[t.tid] = await finances.getLevelLastThree("coaching", {
+		const coachingLevel = await finances.getLevelLastThree("coaching", {
 			t,
 			teamSeasons,
 		});
+
+		if (
+			!g.get("userTids").includes(t.tid) ||
+			local.autoPlayUntil ||
+			g.get("spectator")
+		) {
+			await staff.autoHireByBudget(t.tid, coachingLevel);
+		}
+
+		coachingByTid[t.tid] = await staff.getDevelopmentInfo(t.tid);
 	}
 
 	const players = await idb.cache.players.indexGetAll("playersByTid", [
@@ -383,7 +400,7 @@ const newPhasePreseason = async (
 		} else {
 			// Update ratings
 			player.addRatingsRow(p, scoutingLevel);
-			await player.develop(p, 1, false, coachingLevels[p.tid]);
+			await player.develop(p, 1, false, coachingByTid[p.tid]);
 		}
 
 		if (

--- a/src/worker/core/phase/newPhasePreseason.ts
+++ b/src/worker/core/phase/newPhasePreseason.ts
@@ -250,6 +250,8 @@ const newPhasePreseason = async (
 		throw new Error("scoutingLevel should be defined");
 	}
 
+	await staff.advanceAges();
+
 	const coachingByTid: Record<number, CoachingEffectInput> = {};
 	for (const t of teams) {
 		if (t.disabled) {
@@ -268,13 +270,7 @@ const newPhasePreseason = async (
 			teamSeasons,
 		});
 
-		if (
-			!g.get("userTids").includes(t.tid) ||
-			local.autoPlayUntil ||
-			g.get("spectator")
-		) {
-			await staff.autoHireByBudget(t.tid, coachingLevel);
-		}
+		await staff.autoHireByBudget(t.tid, coachingLevel);
 
 		coachingByTid[t.tid] = g.get("budget")
 			? await staff.getDevelopmentInfo(t.tid)

--- a/src/worker/core/player/develop.ts
+++ b/src/worker/core/player/develop.ts
@@ -17,6 +17,7 @@ import potEstimator from "./potEstimator.ts";
 import { TOO_MANY_TEAMS_TOO_SLOW } from "../season/getInitialNumGamesConfDivSettings.ts";
 import { DEFAULT_LEVEL } from "../../../common/budgetLevels.ts";
 import { bySport, isSport } from "../../../common/sportFunctions.ts";
+import type { CoachingEffectInput } from "../../../common/staff.ts";
 import { last } from "../../../common/utils.ts";
 
 const NUM_SIMULATIONS = 20; // Higher is more accurate, but slower. Low accuracy is fine, though!
@@ -123,7 +124,7 @@ const develop = async (
 	},
 	years: number = 1,
 	newPlayer: boolean = false,
-	coachingLevel: number = DEFAULT_LEVEL,
+	coachingLevel: CoachingEffectInput = DEFAULT_LEVEL,
 	skipPot: boolean = false, // Only for making testing or core/debug faster
 ) => {
 	const ratings = last(p.ratings);

--- a/src/worker/core/player/developSeason.baseball.ts
+++ b/src/worker/core/player/developSeason.baseball.ts
@@ -5,6 +5,11 @@ import type {
 	RatingKey,
 } from "../../../common/types.baseball.ts";
 import { coachingEffect } from "../../../common/budgetLevels.ts";
+import {
+	applyCoachSpecialtyChange,
+	getCoachingLevel,
+	type CoachingEffectInput,
+} from "../../../common/staff.ts";
 import { truncGauss, uniform } from "../../../common/random.ts";
 
 type RatingFormula = {
@@ -202,7 +207,10 @@ const ratingsFormulas: Record<Exclude<RatingKey, "hgt">, RatingFormula> = {
 	endu: powerFormula,
 };
 
-const calcBaseChange = (age: number, coachingLevel: number): number => {
+const calcBaseChange = (
+	age: number,
+	coachingLevel: CoachingEffectInput,
+): number => {
 	let val: number;
 
 	if (age <= 21) {
@@ -234,7 +242,8 @@ const calcBaseChange = (age: number, coachingLevel: number): number => {
 		val += truncGauss(0, 3, -2, 3);
 	}
 
-	val *= 1 + (val > 0 ? 1 : -1) * coachingEffect(coachingLevel);
+	val *=
+		1 + (val > 0 ? 1 : -1) * coachingEffect(getCoachingLevel(coachingLevel));
 
 	return val;
 };
@@ -242,7 +251,7 @@ const calcBaseChange = (age: number, coachingLevel: number): number => {
 const developSeason = (
 	ratings: PlayerRatings,
 	age: number,
-	coachingLevel: number,
+	coachingLevel: CoachingEffectInput,
 ) => {
 	// In young players, height can sometimes increase
 	if (age <= 21) {
@@ -272,13 +281,14 @@ const developSeason = (
 			}
 		}
 
+		const change = helpers.bound(
+			(baseChange + ageModifier) * uniform(0.6, 1.3),
+			changeLimits[0],
+			changeLimits[1],
+		);
+
 		ratings[key] = limitRating(
-			ratings[key] +
-				helpers.bound(
-					(baseChange + ageModifier) * uniform(0.6, 1.3),
-					changeLimits[0],
-					changeLimits[1],
-				),
+			ratings[key] + applyCoachSpecialtyChange(change, coachingLevel, key),
 		);
 	}
 };

--- a/src/worker/core/player/developSeason.basketball.test.ts
+++ b/src/worker/core/player/developSeason.basketball.test.ts
@@ -1,0 +1,62 @@
+import { assert, test, vi } from "vitest";
+import type { PlayerRatings } from "../../../common/types.basketball.ts";
+import developSeason from "./developSeason.basketball.ts";
+
+const seededRandom = (seed: number) => {
+	let state = seed;
+	return () => {
+		state = (state * 16807) % 2147483647;
+		return (state - 1) / 2147483646;
+	};
+};
+
+const makeRatings = (): PlayerRatings => ({
+	diq: 50,
+	dnk: 50,
+	drb: 50,
+	endu: 50,
+	fg: 50,
+	ft: 50,
+	fuzz: 0,
+	hgt: 50,
+	ins: 50,
+	jmp: 50,
+	oiq: 50,
+	ovr: 50,
+	pos: "G",
+	pot: 50,
+	pss: 50,
+	reb: 50,
+	season: 2026,
+	skills: [],
+	spd: 50,
+	stre: 50,
+	tp: 50,
+});
+
+const developWithCoaching = (
+	coachingLevel: Parameters<typeof developSeason>[2],
+) => {
+	const ratings = makeRatings();
+	const random = seededRandom(7);
+	const spy = vi.spyOn(Math, "random").mockImplementation(random);
+	try {
+		developSeason(ratings, 22, coachingLevel);
+	} finally {
+		spy.mockRestore();
+	}
+
+	return ratings;
+};
+
+test("staff quality level has identical development results to the old budget level", () => {
+	const budgetLevel = 62;
+
+	assert.deepStrictEqual(
+		developWithCoaching({
+			level: budgetLevel,
+			specialties: [],
+		}),
+		developWithCoaching(budgetLevel),
+	);
+});

--- a/src/worker/core/player/developSeason.basketball.test.ts
+++ b/src/worker/core/player/developSeason.basketball.test.ts
@@ -1,4 +1,5 @@
 import { assert, test, vi } from "vitest";
+import { DEFAULT_LEVEL } from "../../../common/budgetLevels.ts";
 import type { PlayerRatings } from "../../../common/types.basketball.ts";
 import developSeason from "./developSeason.basketball.ts";
 
@@ -50,13 +51,13 @@ const developWithCoaching = (
 };
 
 test("staff quality level has identical development results to the old budget level", () => {
-	const budgetLevel = 62;
-
-	assert.deepStrictEqual(
-		developWithCoaching({
-			level: budgetLevel,
-			specialties: [],
-		}),
-		developWithCoaching(budgetLevel),
-	);
+	for (const budgetLevel of [62, DEFAULT_LEVEL]) {
+		assert.deepStrictEqual(
+			developWithCoaching({
+				level: budgetLevel,
+				specialties: [],
+			}),
+			developWithCoaching(budgetLevel),
+		);
+	}
 });

--- a/src/worker/core/player/developSeason.basketball.ts
+++ b/src/worker/core/player/developSeason.basketball.ts
@@ -5,6 +5,11 @@ import type {
 	RatingKey,
 } from "../../../common/types.basketball.ts";
 import { coachingEffect } from "../../../common/budgetLevels.ts";
+import {
+	applyCoachSpecialtyChange,
+	getCoachingLevel,
+	type CoachingEffectInput,
+} from "../../../common/staff.ts";
 import { uniform, realGauss } from "../../../common/random.ts";
 
 type RatingFormula = {
@@ -168,7 +173,10 @@ const ratingsFormulas: Record<Exclude<RatingKey, "hgt">, RatingFormula> = {
 	},
 };
 
-const calcBaseChange = (age: number, coachingLevel: number): number => {
+const calcBaseChange = (
+	age: number,
+	coachingLevel: CoachingEffectInput,
+): number => {
 	let val: number;
 
 	if (age <= 21) {
@@ -200,7 +208,8 @@ const calcBaseChange = (age: number, coachingLevel: number): number => {
 		val += helpers.bound(realGauss(0, 3), -2, 4);
 	}
 
-	val *= 1 + (val > 0 ? 1 : -1) * coachingEffect(coachingLevel);
+	val *=
+		1 + (val > 0 ? 1 : -1) * coachingEffect(getCoachingLevel(coachingLevel));
 
 	return val;
 };
@@ -208,7 +217,7 @@ const calcBaseChange = (age: number, coachingLevel: number): number => {
 const developSeason = (
 	ratings: PlayerRatings,
 	age: number,
-	coachingLevel: number,
+	coachingLevel: CoachingEffectInput,
 ) => {
 	// In young players, height can sometimes increase
 	if (age <= 21) {
@@ -229,13 +238,14 @@ const developSeason = (
 		const ageModifier = ratingsFormulas[key].ageModifier(age);
 		const changeLimits = ratingsFormulas[key].changeLimits(age);
 
+		const change = helpers.bound(
+			(baseChange + ageModifier) * uniform(0.4, 1.4),
+			changeLimits[0],
+			changeLimits[1],
+		);
+
 		ratings[key] = limitRating(
-			ratings[key] +
-				helpers.bound(
-					(baseChange + ageModifier) * uniform(0.4, 1.4),
-					changeLimits[0],
-					changeLimits[1],
-				),
+			ratings[key] + applyCoachSpecialtyChange(change, coachingLevel, key),
 		);
 	}
 };

--- a/src/worker/core/player/developSeason.football.ts
+++ b/src/worker/core/player/developSeason.football.ts
@@ -5,6 +5,11 @@ import type {
 	RatingKey,
 } from "../../../common/types.football.ts";
 import { coachingEffect } from "../../../common/budgetLevels.ts";
+import {
+	applyCoachSpecialtyChange,
+	getCoachingLevel,
+	type CoachingEffectInput,
+} from "../../../common/staff.ts";
 import { uniform, truncGauss } from "../../../common/random.ts";
 
 type RatingFormula = {
@@ -121,7 +126,10 @@ const ratingsFormulas: Record<Exclude<RatingKey, "hgt">, RatingFormula> = {
 	pac: iqFormula,
 };
 
-const calcBaseChange = (age: number, coachingLevel: number): number => {
+const calcBaseChange = (
+	age: number,
+	coachingLevel: CoachingEffectInput,
+): number => {
 	let val: number;
 
 	if (age <= 21) {
@@ -149,7 +157,8 @@ const calcBaseChange = (age: number, coachingLevel: number): number => {
 		val += truncGauss(0, 3, -2, 3);
 	}
 
-	val *= 1 + (val > 0 ? 1 : -1) * coachingEffect(coachingLevel);
+	val *=
+		1 + (val > 0 ? 1 : -1) * coachingEffect(getCoachingLevel(coachingLevel));
 
 	return val;
 };
@@ -157,7 +166,7 @@ const calcBaseChange = (age: number, coachingLevel: number): number => {
 const developSeason = (
 	ratings: PlayerRatings,
 	age: number,
-	coachingLevel: number,
+	coachingLevel: CoachingEffectInput,
 ) => {
 	// In young players, height can sometimes increase
 	if (age <= 21) {
@@ -187,13 +196,14 @@ const developSeason = (
 			}
 		}
 
+		const change = helpers.bound(
+			(baseChange + ageModifier) * uniform(0.4, 1.4),
+			changeLimits[0],
+			changeLimits[1],
+		);
+
 		ratings[key] = limitRating(
-			ratings[key] +
-				helpers.bound(
-					(baseChange + ageModifier) * uniform(0.4, 1.4),
-					changeLimits[0],
-					changeLimits[1],
-				),
+			ratings[key] + applyCoachSpecialtyChange(change, coachingLevel, key),
 		);
 	}
 };

--- a/src/worker/core/player/developSeason.hockey.ts
+++ b/src/worker/core/player/developSeason.hockey.ts
@@ -2,6 +2,11 @@ import limitRating from "./limitRating.ts";
 import { helpers } from "../../util/index.ts";
 import type { PlayerRatings, RatingKey } from "../../../common/types.hockey.ts";
 import { coachingEffect } from "../../../common/budgetLevels.ts";
+import {
+	applyCoachSpecialtyChange,
+	getCoachingLevel,
+	type CoachingEffectInput,
+} from "../../../common/staff.ts";
 import { uniform, realGauss } from "../../../common/random.ts";
 
 type RatingFormula = {
@@ -143,7 +148,10 @@ const ratingsFormulas: Record<Exclude<RatingKey, "hgt">, RatingFormula> = {
 	},
 };
 
-const calcBaseChange = (age: number, coachingLevel: number): number => {
+const calcBaseChange = (
+	age: number,
+	coachingLevel: CoachingEffectInput,
+): number => {
 	let val: number;
 
 	if (age <= 21) {
@@ -175,7 +183,8 @@ const calcBaseChange = (age: number, coachingLevel: number): number => {
 		val += helpers.bound(realGauss(0, 3), -2, 4);
 	}
 
-	val *= 1 + (val > 0 ? 1 : -1) * coachingEffect(coachingLevel);
+	val *=
+		1 + (val > 0 ? 1 : -1) * coachingEffect(getCoachingLevel(coachingLevel));
 
 	return val;
 };
@@ -183,7 +192,7 @@ const calcBaseChange = (age: number, coachingLevel: number): number => {
 const developSeason = (
 	ratings: PlayerRatings,
 	age: number,
-	coachingLevel: number,
+	coachingLevel: CoachingEffectInput,
 ) => {
 	// In young players, height can sometimes increase
 	if (age <= 21) {
@@ -205,14 +214,16 @@ const developSeason = (
 		const ageModifier = ratingsFormulas[key].ageModifier(age);
 		const changeLimits = ratingsFormulas[key].changeLimits(age);
 
+		const change =
+			posCoeff *
+			helpers.bound(
+				(baseChange + ageModifier) * uniform(0.2, 1.2),
+				changeLimits[0],
+				changeLimits[1],
+			);
+
 		ratings[key] = limitRating(
-			ratings[key] +
-				posCoeff *
-					helpers.bound(
-						(baseChange + ageModifier) * uniform(0.2, 1.2),
-						changeLimits[0],
-						changeLimits[1],
-					),
+			ratings[key] + applyCoachSpecialtyChange(change, coachingLevel, key),
 		);
 	}
 };

--- a/src/worker/core/player/developSeason.ts
+++ b/src/worker/core/player/developSeason.ts
@@ -9,6 +9,7 @@ import loadDataBasketball from "../realRosters/loadData.basketball.ts";
 import type { Ratings } from "../realRosters/loadData.basketball.ts";
 import limitRating from "./limitRating.ts";
 import { bySport, isSport } from "../../../common/sportFunctions.ts";
+import type { CoachingEffectInput } from "../../../common/staff.ts";
 
 // Cache for performance
 let groupedRatings: Record<string, Ratings> | undefined;
@@ -17,7 +18,7 @@ const developSeason = async (
 	ratings: MinimalPlayerRatings,
 	age: number,
 	srID: string | undefined,
-	coachingLevel: number,
+	coachingLevel: CoachingEffectInput,
 	forPot: boolean,
 ) => {
 	bySport({

--- a/src/worker/core/staff/index.test.ts
+++ b/src/worker/core/staff/index.test.ts
@@ -1,13 +1,17 @@
 import { assert, beforeEach, test } from "vitest";
 import { PLAYER } from "../../../common/constants.ts";
 import { COACH_SLOTS, COACH_SPECIALTIES } from "../../../common/staff.ts";
-import { resetCache } from "../../../test/helpers.ts";
+import { resetCache, resetG } from "../../../test/helpers.ts";
 import { idb } from "../../db/index.ts";
-import { autoHireByBudget } from "./index.ts";
+import { helpers } from "../../util/index.ts";
+import team from "../team/index.ts";
+import { autoHireByBudget, hire } from "./index.ts";
 
 const specialty = COACH_SPECIALTIES[0]!;
 
 beforeEach(async () => {
+	resetG();
+
 	await resetCache({
 		staff: [
 			{
@@ -79,4 +83,37 @@ test("AI auto-hiring respects the coaching budget level", async () => {
 
 	const unaffordableCoach = coaches.find((coach) => coach.coachId === 5);
 	assert.strictEqual(unaffordableCoach?.tid, PLAYER.FREE_AGENT);
+});
+
+test("manual hiring serializes the slot check and assignment", async () => {
+	const [teamInfo] = helpers.getTeamsDefault();
+	await idb.cache.teams.add(team.generate(teamInfo));
+
+	const results = await Promise.allSettled([
+		hire({
+			coachId: 2,
+			slot: "assistant1",
+			tid: 0,
+		}),
+		hire({
+			coachId: 3,
+			slot: "assistant1",
+			tid: 0,
+		}),
+	]);
+
+	assert.strictEqual(
+		results.filter((result) => result.status === "fulfilled").length,
+		1,
+	);
+	assert.strictEqual(
+		results.filter((result) => result.status === "rejected").length,
+		1,
+	);
+
+	const coaches = await idb.cache.staff.getAll();
+	const assistant1Coaches = coaches.filter(
+		(coach) => coach.tid === 0 && coach.slot === "assistant1",
+	);
+	assert.strictEqual(assistant1Coaches.length, 1);
 });

--- a/src/worker/core/staff/index.test.ts
+++ b/src/worker/core/staff/index.test.ts
@@ -1,0 +1,82 @@
+import { assert, beforeEach, test } from "vitest";
+import { PLAYER } from "../../../common/constants.ts";
+import { COACH_SLOTS, COACH_SPECIALTIES } from "../../../common/staff.ts";
+import { resetCache } from "../../../test/helpers.ts";
+import { idb } from "../../db/index.ts";
+import { autoHireByBudget } from "./index.ts";
+
+const specialty = COACH_SPECIALTIES[0]!;
+
+beforeEach(async () => {
+	await resetCache({
+		staff: [
+			{
+				age: 55,
+				coachId: 1,
+				firstName: "Too",
+				lastName: "Expensive",
+				quality: 90,
+				slot: "headCoach",
+				specialty,
+				tid: 0,
+			},
+			{
+				age: 44,
+				coachId: 2,
+				firstName: "Affordable",
+				lastName: "One",
+				quality: 47,
+				specialty,
+				tid: PLAYER.FREE_AGENT,
+			},
+			{
+				age: 45,
+				coachId: 3,
+				firstName: "Affordable",
+				lastName: "Two",
+				quality: 50,
+				specialty,
+				tid: PLAYER.FREE_AGENT,
+			},
+			{
+				age: 46,
+				coachId: 4,
+				firstName: "Affordable",
+				lastName: "Three",
+				quality: 40,
+				specialty,
+				tid: PLAYER.FREE_AGENT,
+			},
+			{
+				age: 47,
+				coachId: 5,
+				firstName: "Still",
+				lastName: "TooExpensive",
+				quality: 60,
+				specialty,
+				tid: PLAYER.FREE_AGENT,
+			},
+		],
+	});
+});
+
+test("AI auto-hiring respects the coaching budget level", async () => {
+	await autoHireByBudget(0, 50);
+
+	const coaches = await idb.cache.staff.getAll();
+	const teamStaff = coaches.filter((coach) => coach.tid === 0);
+
+	assert.strictEqual(teamStaff.length, COACH_SLOTS.length);
+	assert(teamStaff.every((coach) => coach.quality <= 50));
+	assert.deepStrictEqual(
+		teamStaff.map((coach) => coach.slot).sort(),
+		[...COACH_SLOTS].sort(),
+	);
+
+	const firedCoach = coaches.find((coach) => coach.coachId === 1);
+	assert.strictEqual(firedCoach?.tid, PLAYER.FREE_AGENT);
+	assert.strictEqual(firedCoach?.slot, undefined);
+
+	const unaffordableCoach = coaches.find((coach) => coach.coachId === 5);
+	assert.strictEqual(unaffordableCoach?.tid, PLAYER.FREE_AGENT);
+});

--- a/src/worker/core/staff/index.test.ts
+++ b/src/worker/core/staff/index.test.ts
@@ -5,7 +5,7 @@ import { resetCache, resetG } from "../../../test/helpers.ts";
 import { idb } from "../../db/index.ts";
 import { helpers } from "../../util/index.ts";
 import team from "../team/index.ts";
-import { autoHireByBudget, hire } from "./index.ts";
+import { advanceAges, autoHireByBudget, hire } from "./index.ts";
 
 const specialty = COACH_SPECIALTIES[0]!;
 
@@ -83,6 +83,39 @@ test("AI auto-hiring respects the coaching budget level", async () => {
 
 	const unaffordableCoach = coaches.find((coach) => coach.coachId === 5);
 	assert.strictEqual(unaffordableCoach?.tid, PLAYER.FREE_AGENT);
+});
+
+test("user budget downgrade replaces over-grade coaches with affordable coaches", async () => {
+	await autoHireByBudget(0, 50);
+
+	const coaches = await idb.cache.staff.getAll();
+
+	const firedCoach = coaches.find((coach) => coach.coachId === 1);
+	assert.strictEqual(firedCoach?.tid, PLAYER.FREE_AGENT);
+	assert.strictEqual(firedCoach?.slot, undefined);
+
+	const replacementCoach = coaches.find((coach) => coach.coachId === 3);
+	assert.strictEqual(replacementCoach?.tid, 0);
+	assert.strictEqual(replacementCoach?.slot, "headCoach");
+	assert.strictEqual(replacementCoach?.quality, 50);
+});
+
+test("preseason rollover advances every coach age", async () => {
+	await advanceAges();
+
+	const coaches = await idb.cache.staff.getAll();
+	assert.deepStrictEqual(
+		coaches
+			.map((coach) => [coach.coachId, coach.age])
+			.sort((a, b) => a[0]! - b[0]!),
+		[
+			[1, 56],
+			[2, 45],
+			[3, 46],
+			[4, 47],
+			[5, 48],
+		],
+	);
 });
 
 test("manual hiring serializes the slot check and assignment", async () => {

--- a/src/worker/core/staff/index.ts
+++ b/src/worker/core/staff/index.ts
@@ -176,6 +176,15 @@ const makeCoachFreeAgent = async (coach: Coach) => {
 	await idb.cache.staff.put(coach);
 };
 
+export const advanceAges = async () => {
+	const coaches = await idb.cache.staff.getAll();
+
+	for (const coach of coaches) {
+		coach.age += 1;
+		await idb.cache.staff.put(coach);
+	}
+};
+
 const hireBestAffordableCoach = async (
 	slot: CoachSlot,
 	tid: number,
@@ -187,7 +196,7 @@ const hireBestAffordableCoach = async (
 			(coach2) =>
 				coach2.tid === PLAYER.FREE_AGENT && coach2.quality <= budgetLevel,
 		)
-		.sort((a, b) => b.quality - a.quality)[0];
+		.sort((a, b) => b.quality - a.quality || a.coachId - b.coachId)[0];
 
 	if (coach) {
 		coach.tid = tid;
@@ -276,6 +285,7 @@ export const fire = async ({
 };
 
 export default {
+	advanceAges,
 	autoHireByBudget,
 	bootstrapLeagueStaff,
 	fire,

--- a/src/worker/core/staff/index.ts
+++ b/src/worker/core/staff/index.ts
@@ -18,6 +18,27 @@ import playerName from "../player/name.ts";
 const assignedCoach = (coaches: Coach[], tid: number, slot: CoachSlot) =>
 	coaches.find((coach) => coach.tid === tid && coach.slot === slot);
 
+const hireQueues = new Map<string, Promise<unknown>>();
+
+const queueHire = async <T>(
+	tid: number,
+	slot: CoachSlot,
+	callback: () => Promise<T>,
+) => {
+	const key = `${tid}:${slot}`;
+	const previous = hireQueues.get(key) ?? Promise.resolve();
+	const next = previous.catch(() => undefined).then(callback);
+	hireQueues.set(key, next);
+
+	try {
+		return await next;
+	} finally {
+		if (hireQueues.get(key) === next) {
+			hireQueues.delete(key);
+		}
+	}
+};
+
 export const genCoach = async ({
 	quality,
 	slot,
@@ -213,28 +234,30 @@ export const hire = async ({
 	slot: CoachSlot;
 	tid: number;
 }) => {
-	const t = await idb.cache.teams.get(tid);
-	if (!t || t.disabled) {
-		throw new Error("Invalid team");
-	}
+	await queueHire(tid, slot, async () => {
+		const t = await idb.cache.teams.get(tid);
+		if (!t || t.disabled) {
+			throw new Error("Invalid team");
+		}
 
-	const coaches = await idb.cache.staff.getAll();
-	if (assignedCoach(coaches, tid, slot)) {
-		throw new Error("That staff slot is already filled.");
-	}
+		const coaches = await idb.cache.staff.getAll();
+		if (assignedCoach(coaches, tid, slot)) {
+			throw new Error("That staff slot is already filled.");
+		}
 
-	const coach = await idb.cache.staff.get(coachId);
-	if (!coach || coach.tid !== PLAYER.FREE_AGENT) {
-		throw new Error("That coach is not available.");
-	}
+		const coach = await idb.cache.staff.get(coachId);
+		if (!coach || coach.tid !== PLAYER.FREE_AGENT) {
+			throw new Error("That coach is not available.");
+		}
 
-	if (coach.quality > t.budget.coaching) {
-		throw new Error("Your coaching budget level is too low for that coach.");
-	}
+		if (coach.quality > t.budget.coaching) {
+			throw new Error("Your coaching budget level is too low for that coach.");
+		}
 
-	coach.tid = tid;
-	coach.slot = slot;
-	await idb.cache.staff.put(coach);
+		coach.tid = tid;
+		coach.slot = slot;
+		await idb.cache.staff.put(coach);
+	});
 };
 
 export const fire = async ({

--- a/src/worker/core/staff/index.ts
+++ b/src/worker/core/staff/index.ts
@@ -1,0 +1,264 @@
+import { DEFAULT_LEVEL, MAX_LEVEL } from "../../../common/budgetLevels.ts";
+import { PLAYER } from "../../../common/constants.ts";
+import { helpers } from "../../../common/helpers.ts";
+import { choice, randInt } from "../../../common/random.ts";
+import {
+	COACH_SLOTS,
+	COACH_SPECIALTIES,
+	type CoachSlot,
+	type CoachSpecialty,
+	type CoachingEffectInput,
+} from "../../../common/staff.ts";
+import type { Coach, Team } from "../../../common/types.ts";
+import { idb } from "../../db/index.ts";
+import { g } from "../../util/index.ts";
+import finances from "../finances/index.ts";
+import playerName from "../player/name.ts";
+
+const assignedCoach = (coaches: Coach[], tid: number, slot: CoachSlot) =>
+	coaches.find((coach) => coach.tid === tid && coach.slot === slot);
+
+export const genCoach = async ({
+	quality,
+	slot,
+	tid = PLAYER.FREE_AGENT,
+}: {
+	quality: number;
+	slot?: CoachSlot;
+	tid?: number;
+}) => {
+	const name = await playerName();
+
+	return {
+		age: randInt(32, 72),
+		firstName: name.firstName,
+		lastName: name.lastName,
+		quality: helpers.bound(Math.round(quality), 1, MAX_LEVEL),
+		slot,
+		specialty: choice(COACH_SPECIALTIES),
+		tid,
+	};
+};
+
+export const getTeamStaff = (coaches: Coach[], tid: number) =>
+	COACH_SLOTS.map((slot) => assignedCoach(coaches, tid, slot)).filter(
+		(coach): coach is Coach => coach !== undefined,
+	);
+
+export const getDevelopmentInfoFromCoaches = (
+	coaches: Coach[],
+	tid: number,
+): CoachingEffectInput => {
+	let qualityTotal = 0;
+	const specialties: CoachSpecialty[] = [];
+
+	for (const slot of COACH_SLOTS) {
+		const coach = assignedCoach(coaches, tid, slot);
+		if (coach) {
+			qualityTotal += coach.quality;
+			specialties.push(coach.specialty);
+		} else {
+			qualityTotal += DEFAULT_LEVEL;
+		}
+	}
+
+	return {
+		level: helpers.bound(
+			Math.round(qualityTotal / COACH_SLOTS.length),
+			1,
+			MAX_LEVEL,
+		),
+		specialties,
+	};
+};
+
+export const getDevelopmentInfo = async (
+	tid: number,
+): Promise<CoachingEffectInput> => {
+	const coaches = await idb.cache.staff.getAll();
+	return getDevelopmentInfoFromCoaches(coaches, tid);
+};
+
+const getCoachingLevel = async (t: Team) => {
+	const season = g.get("season");
+	const teamSeasons = await idb.getCopies.teamSeasons(
+		{
+			tid: t.tid,
+			seasons: [season - 3, season - 1],
+		},
+		"noCopyCache",
+	);
+
+	return finances.getLevelLastThree("coaching", {
+		t,
+		teamSeasons,
+	});
+};
+
+const ensureTeamStaff = async (
+	coaches: Coach[],
+	tid: number,
+	quality: number,
+) => {
+	for (const slot of COACH_SLOTS) {
+		if (!assignedCoach(coaches, tid, slot)) {
+			const coach = await genCoach({
+				quality,
+				slot,
+				tid,
+			});
+			const coachId = await idb.cache.staff.add(coach);
+			coaches.push({
+				...coach,
+				coachId,
+			});
+		}
+	}
+};
+
+const genFreeAgentQuality = () =>
+	helpers.bound(randInt(DEFAULT_LEVEL - 20, DEFAULT_LEVEL + 55), 1, MAX_LEVEL);
+
+export const bootstrapLeagueStaff = async () => {
+	const coaches = await idb.cache.staff.getAll();
+	if (coaches.length > 0) {
+		return;
+	}
+
+	const teams = (await idb.cache.teams.getAll()).filter((t) => !t.disabled);
+
+	for (const t of teams) {
+		await ensureTeamStaff(coaches, t.tid, await getCoachingLevel(t));
+	}
+
+	const targetFreeAgentCoaches = Math.max(12, teams.length);
+	let numFreeAgentCoaches = coaches.filter(
+		(coach) => coach.tid === PLAYER.FREE_AGENT,
+	).length;
+
+	while (numFreeAgentCoaches < targetFreeAgentCoaches) {
+		const coach = await genCoach({
+			quality: genFreeAgentQuality(),
+		});
+		const coachId = await idb.cache.staff.add(coach);
+		coaches.push({
+			...coach,
+			coachId,
+		});
+		numFreeAgentCoaches += 1;
+	}
+};
+
+const makeCoachFreeAgent = async (coach: Coach) => {
+	coach.tid = PLAYER.FREE_AGENT;
+	delete coach.slot;
+	await idb.cache.staff.put(coach);
+};
+
+const hireBestAffordableCoach = async (
+	slot: CoachSlot,
+	tid: number,
+	budgetLevel: number,
+) => {
+	const coaches = await idb.cache.staff.getAll();
+	const coach = coaches
+		.filter(
+			(coach2) =>
+				coach2.tid === PLAYER.FREE_AGENT && coach2.quality <= budgetLevel,
+		)
+		.sort((a, b) => b.quality - a.quality)[0];
+
+	if (coach) {
+		coach.tid = tid;
+		coach.slot = slot;
+		await idb.cache.staff.put(coach);
+	} else {
+		await idb.cache.staff.add(
+			await genCoach({
+				quality: budgetLevel,
+				slot,
+				tid,
+			}),
+		);
+	}
+};
+
+export const autoHireByBudget = async (tid: number, budgetLevel: number) => {
+	for (const slot of COACH_SLOTS) {
+		const coaches = await idb.cache.staff.getAll();
+		const coach = assignedCoach(coaches, tid, slot);
+
+		if (
+			coach &&
+			coach.quality <= budgetLevel &&
+			coach.quality >= budgetLevel - 12
+		) {
+			continue;
+		}
+
+		if (coach) {
+			await makeCoachFreeAgent(coach);
+		}
+
+		await hireBestAffordableCoach(slot, tid, budgetLevel);
+	}
+};
+
+export const hire = async ({
+	coachId,
+	slot,
+	tid,
+}: {
+	coachId: number;
+	slot: CoachSlot;
+	tid: number;
+}) => {
+	const t = await idb.cache.teams.get(tid);
+	if (!t || t.disabled) {
+		throw new Error("Invalid team");
+	}
+
+	const coaches = await idb.cache.staff.getAll();
+	if (assignedCoach(coaches, tid, slot)) {
+		throw new Error("That staff slot is already filled.");
+	}
+
+	const coach = await idb.cache.staff.get(coachId);
+	if (!coach || coach.tid !== PLAYER.FREE_AGENT) {
+		throw new Error("That coach is not available.");
+	}
+
+	if (coach.quality > t.budget.coaching) {
+		throw new Error("Your coaching budget level is too low for that coach.");
+	}
+
+	coach.tid = tid;
+	coach.slot = slot;
+	await idb.cache.staff.put(coach);
+};
+
+export const fire = async ({
+	coachId,
+	tid,
+}: {
+	coachId: number;
+	tid: number;
+}) => {
+	const coach = await idb.cache.staff.get(coachId);
+	if (!coach || coach.tid !== tid) {
+		throw new Error("Invalid coach.");
+	}
+
+	await makeCoachFreeAgent(coach);
+};
+
+export default {
+	autoHireByBudget,
+	bootstrapLeagueStaff,
+	fire,
+	genCoach,
+	getDevelopmentInfo,
+	getDevelopmentInfoFromCoaches,
+	getTeamStaff,
+	hire,
+};

--- a/src/worker/db/Cache.ts
+++ b/src/worker/db/Cache.ts
@@ -30,6 +30,8 @@ import type {
 	ScheduleGameWithoutKey,
 	ScheduledEvent,
 	ScheduledEventWithoutKey,
+	Coach,
+	CoachWithoutKey,
 	TeamSeason,
 	TeamSeasonWithoutKey,
 	TeamStats,
@@ -71,6 +73,7 @@ export type Store =
 	| "schedule"
 	| "scheduledEvents"
 	| "seasonLeaders"
+	| "staff"
 	| "teamSeasons"
 	| "teamStats"
 	| "teams"
@@ -106,6 +109,7 @@ export const STORES: Store[] = [
 	"schedule",
 	"scheduledEvents",
 	"seasonLeaders",
+	"staff",
 	"teamSeasons",
 	"teamStats",
 	"teams",
@@ -289,6 +293,8 @@ class Cache {
 	scheduledEvents: StoreAPI<ScheduledEventWithoutKey, ScheduledEvent, number>;
 
 	seasonLeaders: StoreAPI<SeasonLeaders, SeasonLeaders, number>;
+
+	staff: StoreAPI<CoachWithoutKey, Coach, number>;
 
 	teamSeasons: StoreAPI<TeamSeasonWithoutKey, TeamSeason, number>;
 
@@ -481,6 +487,12 @@ class Cache {
 						);
 				},
 			},
+			staff: {
+				pk: "coachId",
+				pkType: "number",
+				autoIncrement: true,
+				getData: (tx) => tx.objectStore("staff").getAll(),
+			},
 			teamSeasons: {
 				pk: "rid",
 				pkType: "number",
@@ -576,6 +588,7 @@ class Cache {
 		this.schedule = new StoreAPI(this, "schedule");
 		this.scheduledEvents = new StoreAPI(this, "scheduledEvents");
 		this.seasonLeaders = new StoreAPI(this, "seasonLeaders");
+		this.staff = new StoreAPI(this, "staff");
 		this.teamSeasons = new StoreAPI(this, "teamSeasons");
 		this.teamStats = new StoreAPI(this, "teamStats");
 		this.teams = new StoreAPI(this, "teams");

--- a/src/worker/db/connectLeague.ts
+++ b/src/worker/db/connectLeague.ts
@@ -43,6 +43,7 @@ import type {
 	GameAttributesLeagueWithHistory,
 	SavedTrade,
 	SavedTradingBlock,
+	Coach,
 } from "../../common/types.ts";
 import getInitialNumGamesConfDivSettings from "../core/season/getInitialNumGamesConfDivSettings.ts";
 import { amountToLevel } from "../../common/budgetLevels.ts";
@@ -159,6 +160,11 @@ export interface LeagueDB extends DBSchema {
 	seasonLeaders: {
 		key: number;
 		value: SeasonLeaders;
+	};
+	staff: {
+		key: number;
+		value: Coach;
+		autoIncrementKeyPath: "coachId";
 	};
 	teamSeasons: {
 		key: number;
@@ -592,6 +598,10 @@ const create = (db: IDBPDatabase<LeagueDB>) => {
 	});
 	db.createObjectStore("seasonLeaders", {
 		keyPath: "season",
+	});
+	db.createObjectStore("staff", {
+		keyPath: "coachId",
+		autoIncrement: true,
 	});
 	const teamSeasonsStore = db.createObjectStore("teamSeasons", {
 		keyPath: "rid",
@@ -1733,6 +1743,13 @@ const migrate = async ({
 				await cursor.update(t);
 			}
 		}
+	}
+
+	if (oldVersion < 73) {
+		db.createObjectStore("staff", {
+			keyPath: "coachId",
+			autoIncrement: true,
+		});
 	}
 
 	// Next update - do similar to `oldVersion < 71` above for numPlayoffRounds and draftType, from loadGameAttributes

--- a/src/worker/util/beforeView.ts
+++ b/src/worker/util/beforeView.ts
@@ -1,5 +1,5 @@
 import { Cache, connectLeague, idb } from "../db/index.ts";
-import { league } from "../core/index.ts";
+import { league, staff } from "../core/index.ts";
 import {
 	g,
 	helpers,
@@ -161,6 +161,7 @@ export const beforeLeague = async (newLid: number, conditions?: Conditions) => {
 	}
 
 	await league.loadGameAttributes();
+	await staff.bootstrapLeagueStaff();
 	await initUILocalGames();
 
 	if (loadingNewLid !== newLid) {

--- a/src/worker/views/index.ts
+++ b/src/worker/views/index.ts
@@ -91,6 +91,7 @@ export { default as scheduledEvents } from "./scheduledEvents.ts";
 export { default as seasonPreview } from "./seasonPreview.ts";
 export { default as settings } from "./settings.ts";
 export { default as standings } from "./standings.ts";
+export { default as staff } from "./staff.ts";
 export { default as teamFinances } from "./teamFinances.ts";
 export { default as teamGraphs } from "./teamGraphs.ts";
 export { default as teamHistory } from "./teamHistory.ts";

--- a/src/worker/views/staff.ts
+++ b/src/worker/views/staff.ts
@@ -1,0 +1,46 @@
+import { PLAYER } from "../../common/constants.ts";
+import { getCoachingLevel } from "../../common/staff.ts";
+import type { UpdateEvents, ViewInput } from "../../common/types.ts";
+import { staff as staffCore } from "../core/index.ts";
+import { idb } from "../db/index.ts";
+
+const updateStaff = async (
+	{ abbrev, tid }: ViewInput<"staff">,
+	updateEvents: UpdateEvents,
+	state: any,
+) => {
+	if (
+		updateEvents.includes("firstRun") ||
+		updateEvents.includes("newPhase") ||
+		updateEvents.includes("staff") ||
+		updateEvents.includes("team") ||
+		updateEvents.includes("teamFinances") ||
+		tid !== state.tid
+	) {
+		const t = await idb.cache.teams.get(tid);
+		if (!t || t.disabled) {
+			throw new Error("Team not found");
+		}
+
+		const coaches = await idb.cache.staff.getAll();
+		const developmentInfo = staffCore.getDevelopmentInfoFromCoaches(
+			coaches,
+			tid,
+		);
+
+		return {
+			abbrev,
+			availableCoaches: coaches
+				.filter((coach) => coach.tid === PLAYER.FREE_AGENT)
+				.sort((a, b) => b.quality - a.quality),
+			budgetLevel: t.budget.coaching,
+			developmentLevel: getCoachingLevel(developmentInfo),
+			teamName: t.name,
+			teamRegion: t.region,
+			teamStaff: staffCore.getTeamStaff(coaches, tid),
+			tid,
+		};
+	}
+};
+
+export default updateStaff;

--- a/tools/build/generateJsonSchema.ts
+++ b/tools/build/generateJsonSchema.ts
@@ -2794,6 +2794,48 @@ export const generateJsonSchema = (sport: Sport | "test") => {
 					required: ["hash", "tid"],
 				},
 			},
+			staff: {
+				type: "array",
+				items: {
+					type: "object",
+					properties: {
+						coachId: {
+							type: "integer",
+						},
+						firstName: {
+							type: "string",
+						},
+						lastName: {
+							type: "string",
+						},
+						age: {
+							type: "integer",
+						},
+						specialty: {
+							type: "string",
+						},
+						quality: {
+							type: "integer",
+							minimum: 1,
+							maximum: 100,
+						},
+						tid: {
+							type: "integer",
+						},
+						slot: {
+							enum: ["headCoach", "assistant1", "assistant2"],
+						},
+					},
+					required: [
+						"firstName",
+						"lastName",
+						"age",
+						"specialty",
+						"quality",
+						"tid",
+					],
+				},
+			},
 			trade: {
 				type: "array",
 				items: {


### PR DESCRIPTION
## Summary
A deliberately minimal coaching staff system: head coach + two assistants per team, each with a quality grade and one development specialty. Staff quality replaces the abstract coaching budget level as the development input - budget spend now determines what quality of staff you can afford, so the existing budget -> development pipeline is preserved exactly at parity.

## Why this matters
Coaching is the one development lever players control, and right now it's a single budget slider. OOTP, FM, and DDS all model staff; this brings a scoped-down version of that depth without new balance: a parity test proves development outcomes are identical when staff quality matches the old budget level, and no-budget leagues keep league-average development with no specialty effects.

This is a bigger change than my other PRs, so consider this one a proposal-by-PR: if you'd rather take the idea in a different direction (or keep this subsystem for yourself), happy to adjust or stand down.

## Demo
Simulated Demo:

![demo](https://raw.githubusercontent.com/mvanhorn/zengm/evidence-assets/coaching-staff-demo.gif)

([GIF mirror](https://files.catbox.moe/5mbqko.gif))

## Changes
- New `staff` object store (connectLeague migration); leagues and league files without staff auto-generate, so back-compat is preserved. Coach generation reuses the player-name infrastructure.
- Development hook: the `coachingEffect` call site in `developSeason.*.ts` reads staff quality instead of the raw budget level; specialties add a small multiplier to the matching rating group. Per-sport specialties via bySport for all 4 sports.
- AI teams auto-hire by budget at preseason; manual hires are serialized per slot so concurrent clicks can't double-fill one.
- New Staff page (Team menu) for hire/fire from an available pool, constrained by coaching budget.
- Explicitly out of v1: per-coach contracts, morale, poaching, in-game tactics, coaching history.

## Testing
- Parity test: staff quality == old budget level produces identical development outcomes (including the no-budget case). Concurrent-hire regression test. Full `node --run lint` + `node --run test` pass.
