### PR TITLE
Add 82-0 Draft (God Mode): draft a roster from random real historical teams

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1381,9 +1381,22 @@ export type Local = {
 					disabledCount: number;
 					players: PlayerWithoutKey[];
 					season: number;
+					seasonInfo?: {
+						won: number;
+						lost: number;
+						tied: number;
+						otl: number;
+						roundsWonText?: string;
+					};
 			  } & Pick<
 					Team,
-					"abbrev" | "imgURL" | "name" | "region" | "srID" | "tid"
+					| "abbrev"
+					| "imgURL"
+					| "imgURLSmall"
+					| "name"
+					| "region"
+					| "srID"
+					| "tid"
 			  >)
 			| undefined;
 	};
@@ -1911,8 +1924,9 @@ export type GetLeagueOptionsReal = {
 	realStats: "none" | "lastSeason" | "allActive" | "allActiveHOF" | "all";
 	includePlayers: boolean;
 
-	// For exhibition game only
+	// For callers that need historical team records/players attached to teams
 	includeSeasonInfo?: boolean;
+	preservePlayerOvrContext?: boolean;
 	pidOffset?: number;
 };
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1369,6 +1369,24 @@ export type Local = {
 	};
 	autoSave: boolean;
 	email: string | undefined;
+	eightyTwoZeroDraft?: {
+		round: number;
+		picks: {
+			p: PlayerWithoutKey;
+			teamAbbrev: string;
+			season: number;
+		}[];
+		currentTeam:
+			| ({
+					disabledCount: number;
+					players: PlayerWithoutKey[];
+					season: number;
+			  } & Pick<
+					Team,
+					"abbrev" | "imgURL" | "name" | "region" | "srID" | "tid"
+			  >)
+			| undefined;
+	};
 	exhibitionGamePlayers?: Record<number, Player>;
 	fantasyDraftResults: (Player<any> & {
 		prevAbbrev: string | undefined;

--- a/src/ui/util/menuItems.tsx
+++ b/src/ui/util/menuItems.tsx
@@ -740,6 +740,19 @@ export const menuItems: (MenuItemLink | MenuItemHeader)[] = [
 				path: ["fantasy_draft"],
 				text: "Fantasy Draft",
 			},
+			...(REAL_PLAYERS_INFO
+				? ([
+						{
+							type: "link",
+							active: (pageID) => pageID === "eightyTwoZeroDraft",
+							godMode: true,
+							league: true,
+							commandPalette: true,
+							path: ["eighty_two_zero_draft"],
+							text: "82-0 Draft",
+						},
+					] as MenuItemLink[])
+				: []),
 			{
 				type: "link",
 				active: (pageID) => pageID === "frivolities",

--- a/src/ui/util/routeInfos.ts
+++ b/src/ui/util/routeInfos.ts
@@ -108,6 +108,7 @@ export const routeInfos = {
 	"/l/:lid/team_stat_dists": "teamStatDists",
 	"/l/:lid/team_stat_dists/:season": "teamStatDists",
 	"/l/:lid/export_league": "exportLeague",
+	"/l/:lid/eighty_two_zero_draft": "eightyTwoZeroDraft",
 	"/l/:lid/fantasy_draft": "fantasyDraft",
 	"/l/:lid/live_game": "liveGame",
 	"/l/:lid/event_log": "eventLog",

--- a/src/ui/views/EightyTwoZeroDraft.tsx
+++ b/src/ui/views/EightyTwoZeroDraft.tsx
@@ -1,0 +1,392 @@
+import { useMemo, useState } from "react";
+import { PHASE } from "../../common/constants.ts";
+import { getCols } from "../../common/getCols.ts";
+import type { View } from "../../common/types.ts";
+import { last } from "../../common/utils.ts";
+import { ActionButton } from "../components/ActionButton.tsx";
+import {
+	DataTable,
+	type DataTableRow,
+} from "../components/DataTable/index.tsx";
+import { PlayerNameLabels } from "../components/PlayerNameLabels.tsx";
+import useTitleBar from "../hooks/useTitleBar.tsx";
+import { confirm } from "../util/confirm.tsx";
+import { helpers } from "../util/helpers.ts";
+import { useLocal } from "../util/local.ts";
+import { toWorker } from "../util/toWorker.ts";
+import { applyRealTeamInfos } from "./NewLeague/index.tsx";
+
+const NUM_ROUNDS = 12;
+
+const getErrorMessage = (error: unknown) => {
+	return error instanceof Error ? error.message : String(error);
+};
+
+type EightyTwoZeroDraftPlayer = NonNullable<
+	View<"eightyTwoZeroDraft">["currentTeam"]
+>["players"][number];
+
+const formatPerGameStat = (
+	stats: EightyTwoZeroDraftPlayer["stats"][number] | undefined,
+	stat: "pts" | "trb" | "ast",
+) => {
+	if (!stats || stats.gp === undefined || stats.gp === 0) {
+		return null;
+	}
+
+	let value;
+	if (stat === "trb") {
+		value = (stats.trb ?? 0) + (stats.drb ?? 0) + (stats.orb ?? 0);
+	} else {
+		value = stats[stat];
+	}
+
+	if (typeof value !== "number") {
+		return null;
+	}
+
+	return helpers.roundStat(value / stats.gp, stat);
+};
+
+const PicksList = ({
+	picks,
+}: {
+	picks: View<"eightyTwoZeroDraft">["picks"];
+}) => {
+	if (picks.length === 0) {
+		return null;
+	}
+
+	return (
+		<ol className="list-unstyled mb-3">
+			{picks.map((pick, i) => {
+				const ratings = last(pick.p.ratings);
+				return (
+					<li key={i} className="d-flex gap-2 align-items-baseline">
+						<span className="text-body-secondary text-nowrap">{i + 1}.</span>
+						<span>
+							{pick.p.firstName} {pick.p.lastName}
+						</span>
+						<span className="text-body-secondary">
+							{ratings.pos}, {ratings.ovr} ovr, {pick.season} {pick.teamAbbrev}
+						</span>
+					</li>
+				);
+			})}
+		</ol>
+	);
+};
+
+const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
+	const { realTeamInfo, ...initialDraftState } = props;
+	const [draftState, setDraftState] = useState(initialDraftState);
+	const [errorMessage, setErrorMessage] = useState<string | undefined>();
+	const [finalized, setFinalized] = useState(false);
+	const [processing, setProcessing] = useState<
+		"cancel" | "finalize" | "pick" | "start" | undefined
+	>();
+
+	useTitleBar({
+		title: "82-0 Draft",
+	});
+
+	const { phase } = useLocal(["phase"]);
+
+	const currentTeam = useMemo(() => {
+		if (!draftState.currentTeam) {
+			return;
+		}
+
+		return applyRealTeamInfos(
+			[draftState.currentTeam],
+			realTeamInfo,
+			"inTeamObject",
+		)[0]!;
+	}, [draftState.currentTeam, realTeamInfo]);
+
+	if (!draftState.godMode) {
+		return (
+			<>
+				<h2>Error</h2>
+				<p>God Mode is required for 82-0 Draft.</p>
+			</>
+		);
+	}
+
+	if (!draftState.realPlayers) {
+		return (
+			<>
+				<h2>Error</h2>
+				<p>82-0 Draft is only available for basketball.</p>
+			</>
+		);
+	}
+
+	if (phase === PHASE.DRAFT) {
+		return (
+			<>
+				<h2>Error</h2>
+				<p>
+					You can't start an 82-0 Draft while a regular draft is already in
+					progress.
+				</p>
+			</>
+		);
+	}
+
+	const startDraft = async () => {
+		setErrorMessage(undefined);
+		setFinalized(false);
+		setProcessing("start");
+		try {
+			setDraftState(await toWorker("eightyTwoZeroDraft", "start", undefined));
+		} catch (error) {
+			setErrorMessage(getErrorMessage(error));
+		} finally {
+			setProcessing(undefined);
+		}
+	};
+
+	const cancelDraft = async () => {
+		if (draftState.picks.length > 0) {
+			const proceed = await confirm(
+				`Cancel this draft? Your ${draftState.picks.length} ${helpers.plural(
+					"pick",
+					draftState.picks.length,
+				)} will be lost.`,
+				{
+					okText: "Cancel Draft",
+				},
+			);
+			if (!proceed) {
+				return;
+			}
+		}
+
+		setErrorMessage(undefined);
+		setProcessing("cancel");
+		try {
+			setDraftState(await toWorker("eightyTwoZeroDraft", "cancel", undefined));
+		} catch (error) {
+			setErrorMessage(getErrorMessage(error));
+		} finally {
+			setProcessing(undefined);
+		}
+	};
+
+	const pickPlayer = async (pickIndex: number) => {
+		setErrorMessage(undefined);
+		setProcessing("pick");
+		try {
+			setDraftState(
+				await toWorker("eightyTwoZeroDraft", "pick", {
+					expectedRound: draftState.round,
+					pickIndex,
+				}),
+			);
+		} catch (error) {
+			setErrorMessage(getErrorMessage(error));
+		} finally {
+			setProcessing(undefined);
+		}
+	};
+
+	const finalizeDraft = async () => {
+		const proceed = await confirm(
+			"This deletes your current roster. This cannot be undone.",
+			{
+				okText: "Finalize Draft",
+			},
+		);
+		if (!proceed) {
+			return;
+		}
+
+		setErrorMessage(undefined);
+		setProcessing("finalize");
+		try {
+			setDraftState(
+				await toWorker("eightyTwoZeroDraft", "finalize", undefined),
+			);
+			setFinalized(true);
+		} catch (error) {
+			setErrorMessage(
+				`${getErrorMessage(error)} Check your roster before trying again.`,
+			);
+		} finally {
+			setProcessing(undefined);
+		}
+	};
+
+	if (!draftState.started) {
+		return (
+			<>
+				{finalized ? (
+					<div className="alert alert-success">
+						Your roster was replaced with your 82-0 Draft picks.
+					</div>
+				) : null}
+
+				<p>
+					In an "82-0 Draft", each round shows one random real historical{" "}
+					{process.env.SPORT} team. Draft one player from that roster. Every
+					round locks one more of the team's top players, so later rounds force
+					you deeper into the roster.
+				</p>
+
+				<p>
+					After 12 picks, finalizing the draft deletes your current roster and
+					replaces it with your selected players.
+				</p>
+
+				{errorMessage ? <p className="text-danger">{errorMessage}</p> : null}
+
+				<ActionButton
+					processing={processing === "start"}
+					processingText="Starting"
+					onClick={startDraft}
+				>
+					Start 82-0 Draft
+				</ActionButton>
+			</>
+		);
+	}
+
+	const readyToFinalize = draftState.picks.length === NUM_ROUNDS;
+
+	if (readyToFinalize) {
+		return (
+			<>
+				<h2>Finalize Draft</h2>
+				<PicksList picks={draftState.picks} />
+
+				{errorMessage ? <p className="text-danger">{errorMessage}</p> : null}
+
+				<div className="d-flex gap-2 mb-3">
+					<ActionButton
+						processing={processing === "finalize"}
+						processingText="Finalizing"
+						onClick={finalizeDraft}
+					>
+						Finalize draft
+					</ActionButton>
+					<ActionButton
+						disabled={processing !== undefined}
+						onClick={cancelDraft}
+						processing={processing === "cancel"}
+						processingText="Canceling"
+						variant="light-bordered"
+					>
+						Cancel
+					</ActionButton>
+				</div>
+			</>
+		);
+	}
+
+	if (!currentTeam) {
+		return <p>Loading...</p>;
+	}
+
+	const draftedSrIDs = new Set(
+		draftState.picks.map((pick) => pick.p.srID).filter(Boolean),
+	);
+
+	const cols = getCols(
+		["", "#", "Name", "Pos", "Age", "Ovr", "GP", "PTS", "TRB", "AST"],
+		{
+			Name: {
+				width: "100%",
+			},
+		},
+	);
+
+	const rows: DataTableRow[] = currentTeam.players.map((p, i) => {
+		const ratings = last(p.ratings);
+		const stats = p.stats.at(-1);
+		const locked = i < currentTeam.disabledCount;
+		const alreadyDrafted = p.srID !== undefined && draftedSrIDs.has(p.srID);
+		const disabled =
+			locked ||
+			alreadyDrafted ||
+			processing === "pick" ||
+			processing === "cancel";
+
+		return {
+			key: p.pid ?? i,
+			classNames: locked || alreadyDrafted ? "text-body-secondary" : undefined,
+			data: [
+				locked ? (
+					<span className="badge bg-secondary">Locked</span>
+				) : alreadyDrafted ? (
+					<span className="badge bg-secondary">Drafted</span>
+				) : (
+					<button
+						className="btn btn-xs btn-primary"
+						disabled={disabled}
+						onClick={() => pickPlayer(i)}
+						title="Draft player"
+					>
+						Draft
+					</button>
+				),
+				i + 1,
+				<PlayerNameLabels
+					firstName={p.firstName}
+					lastName={p.lastName}
+					jerseyNumber={stats?.jerseyNumber ?? p.jerseyNumber}
+					skills={ratings.skills}
+					fullNames
+					disableNameLink
+					season={currentTeam.season}
+				/>,
+				ratings.pos,
+				currentTeam.season - p.born.year,
+				ratings.ovr,
+				stats?.gp ?? null,
+				formatPerGameStat(stats, "pts"),
+				formatPerGameStat(stats, "trb"),
+				formatPerGameStat(stats, "ast"),
+			],
+		};
+	});
+
+	return (
+		<>
+			<div className="d-flex justify-content-between align-items-start gap-3 mb-3">
+				<div>
+					<h2 className="mb-0">
+						Round {draftState.round} of {NUM_ROUNDS}
+					</h2>
+					<div className="text-body-secondary">
+						{currentTeam.season} {currentTeam.region} {currentTeam.name}
+					</div>
+				</div>
+				<ActionButton
+					disabled={processing !== undefined}
+					onClick={cancelDraft}
+					processing={processing === "cancel"}
+					processingText="Canceling"
+					variant="light-bordered"
+				>
+					Cancel
+				</ActionButton>
+			</div>
+
+			<PicksList picks={draftState.picks} />
+
+			{errorMessage ? <p className="text-danger">{errorMessage}</p> : null}
+
+			<DataTable
+				cols={cols}
+				defaultSort="disableSort"
+				name="EightyTwoZeroDraft"
+				rows={rows}
+				hideAllControls
+				hideMenuToo
+			/>
+		</>
+	);
+};
+
+export default EightyTwoZeroDraft;

--- a/src/ui/views/EightyTwoZeroDraft.tsx
+++ b/src/ui/views/EightyTwoZeroDraft.tsx
@@ -305,7 +305,18 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 	);
 
 	const cols = getCols(
-		["", "#", "Name", "Pos", "Age", "Ovr", "GP", "PTS", "TRB", "AST"],
+		[
+			"",
+			"#",
+			"Name",
+			"Pos",
+			"Age",
+			"Ovr",
+			"stat:gp",
+			"stat:pts",
+			"stat:trb",
+			"stat:ast",
+		],
 		{
 			Name: {
 				width: "100%",

--- a/src/ui/views/EightyTwoZeroDraft.tsx
+++ b/src/ui/views/EightyTwoZeroDraft.tsx
@@ -8,11 +8,13 @@ import {
 	DataTable,
 	type DataTableRow,
 } from "../components/DataTable/index.tsx";
-import { PlayerNameLabels } from "../components/PlayerNameLabels.tsx";
+import { wrappedPlayerNameLabels } from "../components/PlayerNameLabels.tsx";
+import { RecordAndPlayoffs } from "../components/RecordAndPlayoffs.tsx";
 import useTitleBar from "../hooks/useTitleBar.tsx";
 import { confirm } from "../util/confirm.tsx";
 import { helpers } from "../util/helpers.ts";
 import { useLocal } from "../util/local.ts";
+import { processPlayerStats } from "../util/processPlayerStats.ts";
 import { toWorker } from "../util/toWorker.ts";
 import { applyRealTeamInfos } from "./NewLeague/index.tsx";
 
@@ -40,59 +42,127 @@ type EightyTwoZeroDraftPlayer = NonNullable<
 	View<"eightyTwoZeroDraft">["currentTeam"]
 >["players"][number];
 
-const formatPerGameStat = (
-	stats: EightyTwoZeroDraftPlayer["stats"][number] | undefined,
-	stat: "pts" | "trb" | "ast",
+type EightyTwoZeroDraftStats = View<"eightyTwoZeroDraft">["stats"];
+
+const getProcessedStats = (
+	p: EightyTwoZeroDraftPlayer,
+	stats: EightyTwoZeroDraftStats,
 ) => {
-	if (!stats || stats.gp === undefined || stats.gp === 0) {
-		return null;
-	}
-
-	let value;
-	if (stat === "trb") {
-		value = (stats.trb ?? 0) + (stats.drb ?? 0) + (stats.orb ?? 0);
-	} else {
-		value = stats[stat];
-	}
-
-	if (typeof value !== "number") {
-		return null;
-	}
-
-	return helpers.roundStat(value / stats.gp, stat);
+	const row = p.stats.at(-1);
+	return row
+		? processPlayerStats(row, stats, "perGame", p.born.year)
+		: undefined;
 };
 
-const PicksList = ({
+const formatStat = (
+	processedStats: ReturnType<typeof getProcessedStats>,
+	stat: string,
+) => {
+	const value = processedStats?.[stat];
+	return typeof value === "number" ? helpers.roundStat(value, stat) : value;
+};
+
+const getPlayerNameLabels = (p: EightyTwoZeroDraftPlayer, season: number) => {
+	const ratings = last(p.ratings);
+	const stats = p.stats.at(-1);
+
+	return wrappedPlayerNameLabels({
+		pid: p.pid,
+		firstName: p.firstName,
+		lastName: p.lastName,
+		jerseyNumber: stats?.jerseyNumber ?? p.jerseyNumber,
+		skills: ratings.skills,
+		fullNames: true,
+		disableNameLink: true,
+		season,
+		defaultWatch: p.watch ?? 0,
+	});
+};
+
+const getPlayerTableData = (
+	p: EightyTwoZeroDraftPlayer,
+	season: number,
+	stats: EightyTwoZeroDraftStats,
+) => {
+	const ratings = last(p.ratings);
+	const processedStats = getProcessedStats(p, stats);
+
+	return [
+		getPlayerNameLabels(p, season),
+		ratings.pos,
+		season - p.born.year,
+		ratings.ovr,
+		ratings.pot,
+		...stats.map((stat) => formatStat(processedStats, stat)),
+	];
+};
+
+const DraftedPlayersTable = ({
 	picks,
+	stats,
 }: {
 	picks: View<"eightyTwoZeroDraft">["picks"];
+	stats: EightyTwoZeroDraftStats;
 }) => {
 	if (picks.length === 0) {
 		return null;
 	}
 
+	const cols = getCols(
+		[
+			"Pick",
+			"Name",
+			"Pos",
+			"Age",
+			"Ovr",
+			"Pot",
+			...stats.map((stat) => `stat:${stat}`),
+			"Team",
+		],
+		{
+			Name: {
+				width: "100%",
+			},
+		},
+	);
+
+	const rows: DataTableRow[] = picks.map((pick, i) => {
+		return {
+			key: `${pick.p.pid ?? pick.p.srID ?? i}-${i}`,
+			metadata:
+				pick.p.pid !== undefined
+					? {
+							type: "player",
+							pid: pick.p.pid,
+							season: pick.season,
+							playoffs: "regularSeason",
+						}
+					: undefined,
+			data: [
+				i + 1,
+				...getPlayerTableData(pick.p, pick.season, stats),
+				`${pick.season} ${pick.teamAbbrev}`,
+			],
+		};
+	});
+
 	return (
-		<ol className="list-unstyled mb-3">
-			{picks.map((pick, i) => {
-				const ratings = last(pick.p.ratings);
-				return (
-					<li key={i} className="d-flex gap-2 align-items-baseline">
-						<span className="text-body-secondary text-nowrap">{i + 1}.</span>
-						<span>
-							{pick.p.firstName} {pick.p.lastName}
-						</span>
-						<span className="text-body-secondary">
-							{ratings.pos}, {ratings.ovr} ovr, {pick.season} {pick.teamAbbrev}
-						</span>
-					</li>
-				);
-			})}
-		</ol>
+		<div className="mt-4">
+			<h2>Drafted Players</h2>
+			<DataTable
+				cols={cols}
+				defaultSort="disableSort"
+				name="EightyTwoZeroDraft:Drafted"
+				rows={rows}
+				hideAllControls
+				hideMenuToo
+			/>
+		</div>
 	);
 };
 
 const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
-	const { realTeamInfo, ...initialDraftState } = props;
+	const { realTeamInfo, stats, ...initialDraftState } = props;
 	const [draftState, setDraftState] = useState(initialDraftState);
 	const [errorMessage, setErrorMessage] = useState<string | undefined>();
 	const [finalized, setFinalized] = useState(false);
@@ -241,9 +311,9 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 
 				<p>
 					In an "82-0 Draft", each round shows one random real historical{" "}
-					{process.env.SPORT} team. Draft one player from that roster. Every
-					round locks one more of the team's top players, so later rounds force
-					you deeper into the roster.
+					{process.env.SPORT} team. Draft one player from that roster. Every two
+					rounds, one more of the team's top players is locked, so later rounds
+					force you deeper into the roster.
 				</p>
 
 				<p>
@@ -270,7 +340,7 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 		return (
 			<>
 				<h2>Finalize Draft</h2>
-				<PicksList picks={draftState.picks} />
+				<DraftedPlayersTable picks={draftState.picks} stats={stats} />
 
 				{errorMessage ? <p className="text-danger">{errorMessage}</p> : null}
 
@@ -287,7 +357,7 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 						onClick={cancelDraft}
 						processing={processing === "cancel"}
 						processingText="Canceling"
-						variant="light-bordered"
+						variant="danger"
 					>
 						Cancel
 					</ActionButton>
@@ -306,16 +376,14 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 
 	const cols = getCols(
 		[
-			"",
 			"#",
 			"Name",
 			"Pos",
 			"Age",
 			"Ovr",
-			"stat:gp",
-			"stat:pts",
-			"stat:trb",
-			"stat:ast",
+			"Pot",
+			...stats.map((stat) => `stat:${stat}`),
+			"Draft",
 		],
 		{
 			Name: {
@@ -325,8 +393,6 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 	);
 
 	const rows: DataTableRow[] = currentTeam.players.map((p, i) => {
-		const ratings = last(p.ratings);
-		const stats = p.stats.at(-1);
 		const locked = i < currentTeam.disabledCount;
 		const alreadyDrafted = p.srID !== undefined && draftedSrIDs.has(p.srID);
 		const disabled =
@@ -337,8 +403,19 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 
 		return {
 			key: p.pid ?? i,
+			metadata:
+				p.pid !== undefined
+					? {
+							type: "player",
+							pid: p.pid,
+							season: currentTeam.season,
+							playoffs: "regularSeason",
+						}
+					: undefined,
 			classNames: locked || alreadyDrafted ? "text-body-secondary" : undefined,
 			data: [
+				i + 1,
+				...getPlayerTableData(p, currentTeam.season, stats),
 				locked ? (
 					<span className="badge bg-secondary">Locked</span>
 				) : alreadyDrafted ? (
@@ -353,26 +430,11 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 						Draft
 					</button>
 				),
-				i + 1,
-				<PlayerNameLabels
-					firstName={p.firstName}
-					lastName={p.lastName}
-					jerseyNumber={stats?.jerseyNumber ?? p.jerseyNumber}
-					skills={ratings.skills}
-					fullNames
-					disableNameLink
-					season={currentTeam.season}
-				/>,
-				ratings.pos,
-				currentTeam.season - p.born.year,
-				ratings.ovr,
-				stats?.gp ?? null,
-				formatPerGameStat(stats, "pts"),
-				formatPerGameStat(stats, "trb"),
-				formatPerGameStat(stats, "ast"),
 			],
 		};
 	});
+
+	const logoURL = currentTeam.imgURLSmall ?? currentTeam.imgURL;
 
 	return (
 		<>
@@ -381,8 +443,36 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 					<h2 className="mb-0">
 						Round {draftState.round} of {NUM_ROUNDS}
 					</h2>
-					<div className="text-body-secondary">
-						{currentTeam.season} {currentTeam.region} {currentTeam.name}
+					<div className="d-flex align-items-center gap-2 text-body-secondary">
+						{logoURL ? (
+							<img
+								src={logoURL}
+								alt="Team logo"
+								style={{
+									width: 40,
+									height: 40,
+									objectFit: "contain",
+								}}
+							/>
+						) : null}
+						<div>
+							<div>
+								{currentTeam.season} {currentTeam.region} {currentTeam.name}
+							</div>
+							{currentTeam.seasonInfo ? (
+								<RecordAndPlayoffs
+									abbrev={currentTeam.abbrev}
+									lost={currentTeam.seasonInfo.lost}
+									otl={currentTeam.seasonInfo.otl}
+									option="noSeason"
+									roundsWonText={currentTeam.seasonInfo.roundsWonText}
+									season={currentTeam.season}
+									tid={currentTeam.tid}
+									tied={currentTeam.seasonInfo.tied}
+									won={currentTeam.seasonInfo.won}
+								/>
+							) : null}
+						</div>
 					</div>
 				</div>
 				<ActionButton
@@ -390,13 +480,11 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 					onClick={cancelDraft}
 					processing={processing === "cancel"}
 					processingText="Canceling"
-					variant="light-bordered"
+					variant="danger"
 				>
 					Cancel
 				</ActionButton>
 			</div>
-
-			<PicksList picks={draftState.picks} />
 
 			{errorMessage ? <p className="text-danger">{errorMessage}</p> : null}
 
@@ -408,6 +496,8 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 				hideAllControls
 				hideMenuToo
 			/>
+
+			<DraftedPlayersTable picks={draftState.picks} stats={stats} />
 		</>
 	);
 };

--- a/src/ui/views/EightyTwoZeroDraft.tsx
+++ b/src/ui/views/EightyTwoZeroDraft.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { PHASE } from "../../common/constants.ts";
 import { getCols } from "../../common/getCols.ts";
-import type { View } from "../../common/types.ts";
+import type { Phase, View } from "../../common/types.ts";
 import { last } from "../../common/utils.ts";
 import { ActionButton } from "../components/ActionButton.tsx";
 import {
@@ -20,6 +20,20 @@ const NUM_ROUNDS = 12;
 
 const getErrorMessage = (error: unknown) => {
 	return error instanceof Error ? error.message : String(error);
+};
+
+const getActiveDraftErrorMessage = (phase: Phase) => {
+	if (phase === PHASE.DRAFT) {
+		return "You can't start an 82-0 Draft while a regular draft is already in progress.";
+	}
+
+	if (phase === PHASE.FANTASY_DRAFT) {
+		return "You can't start an 82-0 Draft while a fantasy draft is already in progress.";
+	}
+
+	if (phase === PHASE.EXPANSION_DRAFT) {
+		return "You can't start an 82-0 Draft while an expansion draft is already in progress.";
+	}
 };
 
 type EightyTwoZeroDraftPlayer = NonNullable<
@@ -122,14 +136,12 @@ const EightyTwoZeroDraft = (props: View<"eightyTwoZeroDraft">) => {
 		);
 	}
 
-	if (phase === PHASE.DRAFT) {
+	const activeDraftErrorMessage = getActiveDraftErrorMessage(phase);
+	if (activeDraftErrorMessage) {
 		return (
 			<>
 				<h2>Error</h2>
-				<p>
-					You can't start an 82-0 Draft while a regular draft is already in
-					progress.
-				</p>
+				<p>{activeDraftErrorMessage}</p>
 			</>
 		);
 	}

--- a/src/ui/views/index.ts
+++ b/src/ui/views/index.ts
@@ -28,6 +28,7 @@ export { default as DraftPicks } from "./DraftPicks.tsx";
 export { default as DraftScouting } from "./DraftScouting/index.tsx";
 export { default as DraftTeamHistory } from "./DraftTeamHistory.tsx";
 export { default as Dropbox } from "./Dropbox.tsx";
+export { default as EightyTwoZeroDraft } from "./EightyTwoZeroDraft.tsx";
 export { default as EditAwards } from "./EditAwards.tsx";
 export { default as Exhibition } from "./Exhibition.tsx";
 export { default as ExhibitionGame } from "./ExhibitionGame.tsx";

--- a/src/worker/api/eightyTwoZeroDraft.ts
+++ b/src/worker/api/eightyTwoZeroDraft.ts
@@ -195,7 +195,14 @@ export const start = async () => {
 		picks: [],
 		currentTeam: undefined,
 	};
-	await loadRandomTeam();
+	try {
+		await loadRandomTeam();
+	} catch (error) {
+		// Otherwise a failed initial load leaves started=true with no
+		// currentTeam, and the view is stuck on Loading with no recovery.
+		local.eightyTwoZeroDraft = undefined;
+		throw error;
+	}
 
 	return getState();
 };

--- a/src/worker/api/eightyTwoZeroDraft.ts
+++ b/src/worker/api/eightyTwoZeroDraft.ts
@@ -6,7 +6,7 @@ import {
 } from "../../common/constants.ts";
 import { choice, randInt } from "../../common/random.ts";
 import type { Phase, PlayerWithoutKey, Team } from "../../common/types.ts";
-import { last, orderBy } from "../../common/utils.ts";
+import { last } from "../../common/utils.ts";
 import { player, realRosters, team } from "../core/index.ts";
 import { idb } from "../db/index.ts";
 import { g, helpers, local, toUI, updatePlayMenu } from "../util/index.ts";
@@ -16,14 +16,22 @@ import {
 	countPickablePlayers,
 	getDisabledCount,
 	getPickValidationError,
+	orderPlayersForDraft,
 } from "./eightyTwoZeroDraftHelpers.ts";
 
 type EightyTwoZeroDraftTeam = Pick<
 	Team,
-	"abbrev" | "imgURL" | "name" | "region" | "srID" | "tid"
+	"abbrev" | "imgURL" | "imgURLSmall" | "name" | "region" | "srID" | "tid"
 > & {
 	players: PlayerWithoutKey[];
 	season: number;
+	seasonInfo?: {
+		won: number;
+		lost: number;
+		tied: number;
+		otl: number;
+		roundsWonText?: string;
+	};
 };
 
 let finalizing = false;
@@ -84,52 +92,38 @@ const fetchRandomTeam = async () => {
 		throw new Error("82-0 Draft is only available for basketball.");
 	}
 
-	const oldSeason = g.get("season");
-	const oldNumActiveTeams = g.get("numActiveTeams");
-	const oldPlayerOvrMean = local.playerOvrMean;
-	const oldPlayerOvrStd = local.playerOvrStd;
-	const oldPlayerOvrMeanStdStale = local.playerOvrMeanStdStale;
+	const season = randInt(
+		REAL_PLAYERS_INFO.MIN_SEASON,
+		REAL_PLAYERS_INFO.MAX_SEASON,
+	);
+	const info = await realRosters.getLeagueInfo({
+		type: "real",
+		season,
+		phase: PHASE.PLAYOFFS,
+		randomDebuts: false,
+		randomDebutsKeepCurrent: false,
+		realDraftRatings: "rookie",
+		realStats: "lastSeason",
+		includeSeasonInfo: true,
+		includePlayers: false,
+		pidOffset: local.eightyTwoZeroDraft!.round * 10000,
+		preservePlayerOvrContext: true,
+	});
 
-	try {
-		const season = randInt(
-			REAL_PLAYERS_INFO.MIN_SEASON,
-			REAL_PLAYERS_INFO.MAX_SEASON,
-		);
-		const info = await realRosters.getLeagueInfo({
-			type: "real",
-			season,
-			phase: PHASE.PLAYOFFS,
-			randomDebuts: false,
-			randomDebutsKeepCurrent: false,
-			realDraftRatings: "rookie",
-			realStats: "lastSeason",
-			includeSeasonInfo: true,
-			includePlayers: false,
-		});
-
-		const teams = info.teams as unknown as EightyTwoZeroDraftTeam[];
-		if (teams.length === 0) {
-			throw new Error(`No real teams found for ${season}`);
-		}
-
-		const t = choice(teams);
-		return {
-			...t,
-			disabledCount: getDisabledCount(local.eightyTwoZeroDraft!.round),
-			players: orderBy(
-				t.players.filter((p) => p.ratings.length > 0),
-				(p) => last(p.ratings).ovr,
-				"desc",
-			),
-			season,
-		};
-	} finally {
-		g.setWithoutSavingToDB("season", oldSeason);
-		g.setWithoutSavingToDB("numActiveTeams", oldNumActiveTeams);
-		local.playerOvrMean = oldPlayerOvrMean;
-		local.playerOvrStd = oldPlayerOvrStd;
-		local.playerOvrMeanStdStale = oldPlayerOvrMeanStdStale;
+	const teams = info.teams as unknown as EightyTwoZeroDraftTeam[];
+	if (teams.length === 0) {
+		throw new Error(`No real teams found for ${season}`);
 	}
+
+	const t = choice(teams);
+	return {
+		...t,
+		disabledCount: getDisabledCount(local.eightyTwoZeroDraft!.round),
+		players: orderPlayersForDraft(
+			t.players.filter((p) => p.ratings.length > 0),
+		),
+		season,
+	};
 };
 
 const getCappedDisabledCount = (round: number, players: PlayerWithoutKey[]) => {

--- a/src/worker/api/eightyTwoZeroDraft.ts
+++ b/src/worker/api/eightyTwoZeroDraft.ts
@@ -1,0 +1,336 @@
+import { DEFAULT_LEVEL } from "../../common/budgetLevels.ts";
+import {
+	LEAGUE_DATABASE_VERSION,
+	PHASE,
+	REAL_PLAYERS_INFO,
+} from "../../common/constants.ts";
+import { choice, randInt } from "../../common/random.ts";
+import type { PlayerWithoutKey, Team } from "../../common/types.ts";
+import { last, orderBy } from "../../common/utils.ts";
+import { player, realRosters, team } from "../core/index.ts";
+import { idb } from "../db/index.ts";
+import { g, helpers, local, toUI, updatePlayMenu } from "../util/index.ts";
+import {
+	MAX_RANDOM_TEAM_RETRIES,
+	NUM_EIGHTY_TWO_ZERO_DRAFT_ROUNDS,
+	countPickablePlayers,
+	getDisabledCount,
+	getPickValidationError,
+} from "./eightyTwoZeroDraftHelpers.ts";
+
+type EightyTwoZeroDraftTeam = Pick<
+	Team,
+	"abbrev" | "imgURL" | "name" | "region" | "srID" | "tid"
+> & {
+	players: PlayerWithoutKey[];
+	season: number;
+};
+
+let finalizing = false;
+
+const getState = () => {
+	const draft = local.eightyTwoZeroDraft;
+	return {
+		godMode: g.get("godMode"),
+		loading: false,
+		realPlayers: REAL_PLAYERS_INFO !== undefined,
+		started: draft !== undefined,
+		...(draft ?? {
+			currentTeam: undefined,
+			picks: [],
+			round: 1,
+		}),
+	};
+};
+
+const checkCanUse = () => {
+	if (!g.get("godMode")) {
+		throw new Error("God Mode is required for 82-0 Draft.");
+	}
+
+	if (!REAL_PLAYERS_INFO) {
+		throw new Error("82-0 Draft is only available for basketball.");
+	}
+
+	if (g.get("phase") === PHASE.DRAFT) {
+		throw new Error(
+			"You can't start an 82-0 Draft while a regular draft is already in progress.",
+		);
+	}
+};
+
+const fetchRandomTeam = async () => {
+	if (!REAL_PLAYERS_INFO) {
+		throw new Error("82-0 Draft is only available for basketball.");
+	}
+
+	const oldSeason = g.get("season");
+	const oldNumActiveTeams = g.get("numActiveTeams");
+	const oldPlayerOvrMean = local.playerOvrMean;
+	const oldPlayerOvrStd = local.playerOvrStd;
+	const oldPlayerOvrMeanStdStale = local.playerOvrMeanStdStale;
+
+	try {
+		const season = randInt(
+			REAL_PLAYERS_INFO.MIN_SEASON,
+			REAL_PLAYERS_INFO.MAX_SEASON,
+		);
+		const info = await realRosters.getLeagueInfo({
+			type: "real",
+			season,
+			phase: PHASE.PLAYOFFS,
+			randomDebuts: false,
+			randomDebutsKeepCurrent: false,
+			realDraftRatings: "rookie",
+			realStats: "lastSeason",
+			includeSeasonInfo: true,
+			includePlayers: false,
+		});
+
+		const teams = info.teams as unknown as EightyTwoZeroDraftTeam[];
+		if (teams.length === 0) {
+			throw new Error(`No real teams found for ${season}`);
+		}
+
+		const t = choice(teams);
+		return {
+			...t,
+			disabledCount: getDisabledCount(local.eightyTwoZeroDraft!.round),
+			players: orderBy(
+				t.players.filter((p) => p.ratings.length > 0),
+				(p) => last(p.ratings).ovr,
+				"desc",
+			),
+			season,
+		};
+	} finally {
+		g.setWithoutSavingToDB("season", oldSeason);
+		g.setWithoutSavingToDB("numActiveTeams", oldNumActiveTeams);
+		local.playerOvrMean = oldPlayerOvrMean;
+		local.playerOvrStd = oldPlayerOvrStd;
+		local.playerOvrMeanStdStale = oldPlayerOvrMeanStdStale;
+	}
+};
+
+const getCappedDisabledCount = (round: number, players: PlayerWithoutKey[]) => {
+	return Math.min(getDisabledCount(round), Math.max(players.length - 1, 0));
+};
+
+const loadRandomTeam = async () => {
+	const draft = local.eightyTwoZeroDraft;
+	if (!draft) {
+		throw new Error("No 82-0 Draft in progress.");
+	}
+
+	let fallback:
+		| (EightyTwoZeroDraftTeam & {
+				disabledCount: number;
+		  })
+		| undefined;
+
+	for (let i = 0; i < MAX_RANDOM_TEAM_RETRIES; i++) {
+		const currentTeam = await fetchRandomTeam();
+		const pickableCount = countPickablePlayers(
+			currentTeam.players,
+			getDisabledCount(draft.round),
+			draft.picks,
+		);
+		if (pickableCount > 0) {
+			draft.currentTeam = currentTeam;
+			return;
+		}
+
+		const cappedDisabledCount = getCappedDisabledCount(
+			draft.round,
+			currentTeam.players,
+		);
+		if (
+			!fallback &&
+			countPickablePlayers(
+				currentTeam.players,
+				cappedDisabledCount,
+				draft.picks,
+			) > 0
+		) {
+			fallback = {
+				...currentTeam,
+				disabledCount: cappedDisabledCount,
+			};
+		}
+	}
+
+	if (fallback) {
+		draft.currentTeam = fallback;
+		return;
+	}
+
+	throw new Error("Could not find a real team with an available player.");
+};
+
+export const start = async () => {
+	checkCanUse();
+
+	local.eightyTwoZeroDraft = {
+		round: 1,
+		picks: [],
+		currentTeam: undefined,
+	};
+	await loadRandomTeam();
+
+	return getState();
+};
+
+export const pick = async ({
+	expectedRound,
+	pickIndex,
+}: {
+	expectedRound: number;
+	pickIndex: number;
+}) => {
+	checkCanUse();
+
+	const draft = local.eightyTwoZeroDraft;
+	if (!draft) {
+		throw new Error("No 82-0 Draft in progress.");
+	}
+
+	if (draft.round !== expectedRound) {
+		throw new Error("This draft has already advanced to another round.");
+	}
+
+	const currentTeam = draft.currentTeam;
+	if (!currentTeam) {
+		throw new Error("No team is available for this round.");
+	}
+
+	const validationError = getPickValidationError({
+		disabledCount: currentTeam.disabledCount,
+		pickIndex,
+		picks: draft.picks,
+		players: currentTeam.players,
+	});
+	if (validationError) {
+		throw new Error(validationError);
+	}
+
+	const p = helpers.deepCopy(currentTeam.players[pickIndex]!);
+	draft.picks.push({
+		p,
+		teamAbbrev: currentTeam.abbrev,
+		season: currentTeam.season,
+	});
+
+	if (draft.picks.length === NUM_EIGHTY_TWO_ZERO_DRAFT_ROUNDS) {
+		draft.currentTeam = undefined;
+		return getState();
+	}
+
+	draft.round += 1;
+	draft.currentTeam = undefined;
+	await loadRandomTeam();
+
+	return getState();
+};
+
+const normalizePick = async (
+	pick: NonNullable<typeof local.eightyTwoZeroDraft>["picks"][number],
+	teamJerseyNumbers: string[],
+) => {
+	const p = helpers.deepCopy(pick.p);
+	delete p.pid;
+
+	const seasonOffset = g.get("season") - pick.season;
+	p.born.year += seasonOffset;
+	p.draft.year += seasonOffset;
+	p.tid = g.get("userTid");
+	p.retiredYear = Infinity;
+	p.gamesUntilTradable = 0;
+	p.injuries = [];
+	p.injury = {
+		type: "Healthy",
+		gamesRemaining: 0,
+	};
+	p.numDaysFreeAgent = 0;
+	p.ptModifier = 1;
+	p.salaries = [];
+	p.stats = [];
+	p.statsTids = [];
+	p.watch = undefined;
+	p.yearsFreeAgent = 0;
+
+	const ratings = helpers.deepCopy(last(p.ratings));
+	ratings.season = g.get("season");
+	p.ratings = [ratings];
+	p.draft.ovr = ratings.ovr;
+	p.draft.pot = ratings.pot;
+	p.draft.skills = ratings.skills;
+
+	player.setContract(
+		p,
+		{
+			amount: g.get("minContract"),
+			exp: g.get("season"),
+		},
+		true,
+	);
+
+	const p2 = await player.augmentPartialPlayer(
+		p,
+		DEFAULT_LEVEL,
+		LEAGUE_DATABASE_VERSION,
+	);
+	player.setJerseyNumber(
+		p2,
+		await player.genJerseyNumber(p2, teamJerseyNumbers),
+	);
+	teamJerseyNumbers.push(p2.jerseyNumber!);
+	await player.updateValues(p2);
+
+	return p2;
+};
+
+export const finalize = async () => {
+	checkCanUse();
+
+	if (finalizing) {
+		throw new Error("82-0 Draft is already finalizing.");
+	}
+
+	const draft = local.eightyTwoZeroDraft;
+	if (!draft || draft.picks.length !== NUM_EIGHTY_TWO_ZERO_DRAFT_ROUNDS) {
+		throw new Error("You must draft 12 players before finalizing.");
+	}
+
+	finalizing = true;
+	try {
+		const teamJerseyNumbers: string[] = [];
+		const playersToAdd: PlayerWithoutKey[] = [];
+		for (const pick of draft.picks) {
+			playersToAdd.push(await normalizePick(pick, teamJerseyNumbers));
+		}
+
+		const oldRoster = await idb.cache.players.indexGetAll(
+			"playersByTid",
+			g.get("userTid"),
+		);
+		await player.remove(oldRoster.map((p) => p.pid));
+
+		for (const p of playersToAdd) {
+			await idb.cache.players.put(p);
+		}
+		await team.rosterAutoSort(g.get("userTid"), false);
+
+		local.eightyTwoZeroDraft = undefined;
+		await updatePlayMenu();
+		await toUI("realtimeUpdate", [["playerMovement"]]);
+
+		return getState();
+	} finally {
+		finalizing = false;
+	}
+};
+
+export const cancel = async () => {
+	local.eightyTwoZeroDraft = undefined;
+	return getState();
+};

--- a/src/worker/api/eightyTwoZeroDraft.ts
+++ b/src/worker/api/eightyTwoZeroDraft.ts
@@ -5,7 +5,7 @@ import {
 	REAL_PLAYERS_INFO,
 } from "../../common/constants.ts";
 import { choice, randInt } from "../../common/random.ts";
-import type { PlayerWithoutKey, Team } from "../../common/types.ts";
+import type { Phase, PlayerWithoutKey, Team } from "../../common/types.ts";
 import { last, orderBy } from "../../common/utils.ts";
 import { player, realRosters, team } from "../core/index.ts";
 import { idb } from "../db/index.ts";
@@ -28,9 +28,24 @@ type EightyTwoZeroDraftTeam = Pick<
 
 let finalizing = false;
 
+const getActiveDraftErrorMessage = (phase: Phase) => {
+	if (phase === PHASE.DRAFT) {
+		return "You can't start an 82-0 Draft while a regular draft is already in progress.";
+	}
+
+	if (phase === PHASE.FANTASY_DRAFT) {
+		return "You can't start an 82-0 Draft while a fantasy draft is already in progress.";
+	}
+
+	if (phase === PHASE.EXPANSION_DRAFT) {
+		return "You can't start an 82-0 Draft while an expansion draft is already in progress.";
+	}
+};
+
 const getState = () => {
 	const draft = local.eightyTwoZeroDraft;
 	return {
+		activeDraftErrorMessage: getActiveDraftErrorMessage(g.get("phase")),
 		godMode: g.get("godMode"),
 		loading: false,
 		realPlayers: REAL_PLAYERS_INFO !== undefined,
@@ -52,11 +67,16 @@ const checkCanUse = () => {
 		throw new Error("82-0 Draft is only available for basketball.");
 	}
 
-	if (g.get("phase") === PHASE.DRAFT) {
-		throw new Error(
-			"You can't start an 82-0 Draft while a regular draft is already in progress.",
-		);
+	const activeDraftErrorMessage = getActiveDraftErrorMessage(g.get("phase"));
+	if (activeDraftErrorMessage) {
+		throw new Error(activeDraftErrorMessage);
 	}
+};
+
+const getContractExp = () => {
+	return (
+		g.get("season") + (g.get("phase") > PHASE.AFTER_TRADE_DEADLINE ? 1 : 0)
+	);
 };
 
 const fetchRandomTeam = async () => {
@@ -213,6 +233,7 @@ export const pick = async ({
 		throw new Error(validationError);
 	}
 
+	const previousRound = draft.round;
 	const p = helpers.deepCopy(currentTeam.players[pickIndex]!);
 	draft.picks.push({
 		p,
@@ -227,7 +248,14 @@ export const pick = async ({
 
 	draft.round += 1;
 	draft.currentTeam = undefined;
-	await loadRandomTeam();
+	try {
+		await loadRandomTeam();
+	} catch (error) {
+		draft.picks.pop();
+		draft.round = previousRound;
+		draft.currentTeam = currentTeam;
+		throw error;
+	}
 
 	return getState();
 };
@@ -269,7 +297,7 @@ const normalizePick = async (
 		p,
 		{
 			amount: g.get("minContract"),
-			exp: g.get("season"),
+			exp: getContractExp(),
 		},
 		true,
 	);

--- a/src/worker/api/eightyTwoZeroDraftHelpers.test.ts
+++ b/src/worker/api/eightyTwoZeroDraftHelpers.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+import {
+	countPickablePlayers,
+	getDisabledCount,
+	getPickValidationError,
+} from "./eightyTwoZeroDraftHelpers.ts";
+
+const players = [
+	{ srID: "a" },
+	{ srID: "b" },
+	{ srID: "c" },
+	{ srID: "d" },
+	{ srID: "e" },
+	{ srID: "f" },
+	{ srID: "g" },
+	{ srID: "h" },
+	{ srID: "i" },
+	{ srID: "j" },
+	{ srID: "k" },
+	{ srID: "l" },
+];
+
+describe("getDisabledCount", () => {
+	test("locks one more top player each round", () => {
+		expect(getDisabledCount(1)).toBe(0);
+		expect(getDisabledCount(4)).toBe(3);
+		expect(getDisabledCount(12)).toBe(11);
+	});
+});
+
+describe("getPickValidationError", () => {
+	test("rejects duplicate srID picks", () => {
+		expect(
+			getPickValidationError({
+				disabledCount: 0,
+				pickIndex: 1,
+				picks: [{ p: { srID: "b" } }],
+				players,
+			}),
+		).toBe("You already drafted this player");
+	});
+
+	test("rejects out-of-range picks", () => {
+		expect(
+			getPickValidationError({
+				disabledCount: 0,
+				pickIndex: 12,
+				picks: [],
+				players,
+			}),
+		).toBe("Invalid player");
+	});
+
+	test("rejects locked picks", () => {
+		expect(
+			getPickValidationError({
+				disabledCount: getDisabledCount(4),
+				pickIndex: 2,
+				picks: [],
+				players,
+			}),
+		).toBe("This player is locked");
+	});
+});
+
+describe("countPickablePlayers", () => {
+	test("counts only unlocked non-duplicate players", () => {
+		expect(
+			countPickablePlayers(players.slice(0, 5), 3, [{ p: { srID: "d" } }]),
+		).toBe(1);
+	});
+});

--- a/src/worker/api/eightyTwoZeroDraftHelpers.test.ts
+++ b/src/worker/api/eightyTwoZeroDraftHelpers.test.ts
@@ -3,6 +3,7 @@ import {
 	countPickablePlayers,
 	getDisabledCount,
 	getPickValidationError,
+	orderPlayersForDraft,
 } from "./eightyTwoZeroDraftHelpers.ts";
 
 const players = [
@@ -21,10 +22,24 @@ const players = [
 ];
 
 describe("getDisabledCount", () => {
-	test("locks one more top player each round", () => {
+	test("locks one more top player every two rounds", () => {
 		expect(getDisabledCount(1)).toBe(0);
-		expect(getDisabledCount(4)).toBe(3);
-		expect(getDisabledCount(12)).toBe(11);
+		expect(getDisabledCount(2)).toBe(0);
+		expect(getDisabledCount(3)).toBe(1);
+		expect(getDisabledCount(4)).toBe(1);
+		expect(getDisabledCount(12)).toBe(5);
+	});
+});
+
+describe("orderPlayersForDraft", () => {
+	test("sorts by valueFuzz descending", () => {
+		expect(
+			orderPlayersForDraft([
+				{ srID: "a", valueFuzz: 45, ovr: 90 },
+				{ srID: "b", valueFuzz: 60, ovr: 70 },
+				{ srID: "c", valueFuzz: 50, ovr: 80 },
+			]).map((p) => p.srID),
+		).toEqual(["b", "c", "a"]);
 	});
 });
 
@@ -54,8 +69,8 @@ describe("getPickValidationError", () => {
 	test("rejects locked picks", () => {
 		expect(
 			getPickValidationError({
-				disabledCount: getDisabledCount(4),
-				pickIndex: 2,
+				disabledCount: getDisabledCount(5),
+				pickIndex: 1,
 				picks: [],
 				players,
 			}),

--- a/src/worker/api/eightyTwoZeroDraftHelpers.ts
+++ b/src/worker/api/eightyTwoZeroDraftHelpers.ts
@@ -2,6 +2,10 @@ type PlayerLike = {
 	srID?: string;
 };
 
+type PlayerWithValue = PlayerLike & {
+	valueFuzz: number;
+};
+
 type PickLike = {
 	p: PlayerLike;
 };
@@ -11,7 +15,13 @@ export const NUM_EIGHTY_TWO_ZERO_DRAFT_ROUNDS = 12;
 export const MAX_RANDOM_TEAM_RETRIES = 20;
 
 export const getDisabledCount = (round: number) => {
-	return round - 1;
+	return Math.floor((round - 1) / 2);
+};
+
+export const orderPlayersForDraft = <T extends PlayerWithValue>(
+	players: readonly T[],
+) => {
+	return [...players].sort((a, b) => b.valueFuzz - a.valueFuzz);
 };
 
 export const isDuplicateSrID = (p: PlayerLike, picks: readonly PickLike[]) => {

--- a/src/worker/api/eightyTwoZeroDraftHelpers.ts
+++ b/src/worker/api/eightyTwoZeroDraftHelpers.ts
@@ -1,0 +1,60 @@
+type PlayerLike = {
+	srID?: string;
+};
+
+type PickLike = {
+	p: PlayerLike;
+};
+
+export const NUM_EIGHTY_TWO_ZERO_DRAFT_ROUNDS = 12;
+
+export const MAX_RANDOM_TEAM_RETRIES = 20;
+
+export const getDisabledCount = (round: number) => {
+	return round - 1;
+};
+
+export const isDuplicateSrID = (p: PlayerLike, picks: readonly PickLike[]) => {
+	return (
+		p.srID !== undefined &&
+		picks.some((pick) => pick.p.srID !== undefined && pick.p.srID === p.srID)
+	);
+};
+
+export const countPickablePlayers = (
+	players: readonly PlayerLike[],
+	disabledCount: number,
+	picks: readonly PickLike[],
+) => {
+	return players.filter((p, i) => {
+		return i >= disabledCount && !isDuplicateSrID(p, picks);
+	}).length;
+};
+
+export const getPickValidationError = ({
+	disabledCount,
+	pickIndex,
+	picks,
+	players,
+}: {
+	disabledCount: number;
+	pickIndex: number;
+	picks: readonly PickLike[];
+	players: readonly PlayerLike[];
+}) => {
+	if (
+		!Number.isInteger(pickIndex) ||
+		pickIndex < 0 ||
+		pickIndex >= players.length
+	) {
+		return "Invalid player";
+	}
+
+	if (pickIndex < disabledCount) {
+		return "This player is locked";
+	}
+
+	if (isDuplicateSrID(players[pickIndex]!, picks)) {
+		return "You already drafted this player";
+	}
+};

--- a/src/worker/api/index.ts
+++ b/src/worker/api/index.ts
@@ -1730,6 +1730,24 @@ const getDefaultTragicDeaths = () => {
 	return defaultTragicDeaths;
 };
 
+const getEightyTwoZeroDraftPlayer = (pid: number): Player | undefined => {
+	const draft = local.eightyTwoZeroDraft;
+	if (!draft) {
+		return;
+	}
+
+	const hasPid = (p: PlayerWithoutKey): p is Player => {
+		return p.pid === pid;
+	};
+
+	const currentTeamPlayer = draft.currentTeam?.players.find(hasPid);
+	if (currentTeamPlayer) {
+		return currentTeamPlayer;
+	}
+
+	return draft.picks.find((pick) => hasPid(pick.p))?.p as Player | undefined;
+};
+
 const getDiamondInfo = async (pid: number) => {
 	let p;
 	if (local.exhibitionGamePlayers) {
@@ -2039,7 +2057,10 @@ const getPlayerWatch = async (pid: number) => {
 			return 0;
 		}
 	} else {
-		p = await idb.cache.players.get(pid);
+		p = getEightyTwoZeroDraftPlayer(pid);
+		if (!p) {
+			p = await idb.cache.players.get(pid);
+		}
 	}
 
 	if (p) {
@@ -2921,10 +2942,14 @@ const ratingsStatsPopoverInfo = async ({
 	}
 
 	let p;
+	let eightyTwoZeroDraftPlayer = false;
 	if (local.exhibitionGamePlayers) {
 		p = local.exhibitionGamePlayers[pid];
 	} else if (local.liveSimRatingsStatsPopoverPlayers) {
 		p = local.liveSimRatingsStatsPopoverPlayers[pid];
+	} else {
+		p = getEightyTwoZeroDraftPlayer(pid);
+		eightyTwoZeroDraftPlayer = p !== undefined;
 	}
 
 	if (!p) {
@@ -2944,7 +2969,10 @@ const ratingsStatsPopoverInfo = async ({
 
 	let actualSeason: number | undefined;
 	let draftProspect = false;
-	if (local.exhibitionGamePlayers && p.stats.length > 0) {
+	if (
+		(local.exhibitionGamePlayers || eightyTwoZeroDraftPlayer) &&
+		p.stats.length > 0
+	) {
 		actualSeason = p.stats.at(-1)!.season;
 	} else {
 		if (season !== undefined) {
@@ -2994,7 +3022,7 @@ const ratingsStatsPopoverInfo = async ({
 
 	const attrs = ["name", "jerseyNumber", "tid", "age", "note"];
 	const ratings = ["pos", "ovr", "pot", "season", "tid", ...RATINGS];
-	if (!local.exhibitionGamePlayers) {
+	if (!local.exhibitionGamePlayers && !eightyTwoZeroDraftPlayer) {
 		attrs.push("abbrev");
 		ratings.push("abbrev");
 	}
@@ -3021,7 +3049,10 @@ const ratingsStatsPopoverInfo = async ({
 		p2.stats = p2.careerStats;
 		delete p2.careerStats;
 	}
-	if (actualSeason === undefined || actualSeason < currentSeason) {
+	if (
+		!eightyTwoZeroDraftPlayer &&
+		(actualSeason === undefined || actualSeason < currentSeason)
+	) {
 		p2.abbrev = p2.ratings.abbrev;
 		p2.tid = p2.ratings.tid;
 	}
@@ -4166,25 +4197,32 @@ const updatePlayerWatch = async ({
 	watch: number;
 }) => {
 	let p;
+	let eightyTwoZeroDraftPlayer = false;
 	if (local.exhibitionGamePlayers) {
 		p = local.exhibitionGamePlayers[pid];
 		if (!p) {
 			return;
 		}
 	} else {
-		p = await idb.getCopy.players({ pid }, "noCopyCache");
+		p = getEightyTwoZeroDraftPlayer(pid);
+		eightyTwoZeroDraftPlayer = p !== undefined;
+		if (!p) {
+			p = await idb.getCopy.players({ pid }, "noCopyCache");
+		}
 	}
 
 	if (p) {
 		if (
 			watch < 1 ||
-			(!local.exhibitionGamePlayers && watch > g.get("numWatchColors"))
+			(!local.exhibitionGamePlayers &&
+				!eightyTwoZeroDraftPlayer &&
+				watch > g.get("numWatchColors"))
 		) {
 			delete p.watch;
 		} else {
 			p.watch = watch;
 		}
-		if (!local.exhibitionGamePlayers) {
+		if (!local.exhibitionGamePlayers && !eightyTwoZeroDraftPlayer) {
 			await idb.cache.players.put(p);
 			await Promise.all([
 				toUI("crossTabEmit", [["updateWatch", getUpdateWatch([p])]]),

--- a/src/worker/api/index.ts
+++ b/src/worker/api/index.ts
@@ -106,6 +106,7 @@ import {
 } from "../db/connectLeague.ts";
 import playMenu from "./playMenu.ts";
 import toolsMenu from "./toolsMenu.ts";
+import * as eightyTwoZeroDraft from "./eightyTwoZeroDraft.ts";
 import addFirstNameShort from "../util/addFirstNameShort.ts";
 import statsBaseball from "../core/team/stats.baseball.ts";
 import { extraRatings } from "../views/playerRatings.ts";
@@ -5163,6 +5164,7 @@ const setScheduleFromEditor = async ({
 
 export default {
 	actions,
+	eightyTwoZeroDraft,
 	exhibitionGame,
 	leagueFileUpload,
 	playMenu,

--- a/src/worker/core/realRosters/addSeasonInfoToTeams.ts
+++ b/src/worker/core/realRosters/addSeasonInfoToTeams.ts
@@ -103,14 +103,30 @@ const addSeasonInfoToTeams = async <
 			return p2;
 		});
 
-	g.setWithoutSavingToDB("season", options.season);
-	g.setWithoutSavingToDB("numActiveTeams", 2);
-	local.playerOvrMean = 48;
-	local.playerOvrStd = 10;
-	local.playerOvrMeanStdStale = false;
-	for (const p of players) {
-		await player.develop(p, 0);
-		await player.updateValues(p);
+	const oldSeason = g.get("season");
+	const oldNumActiveTeams = g.get("numActiveTeams");
+	const oldPlayerOvrMean = local.playerOvrMean;
+	const oldPlayerOvrStd = local.playerOvrStd;
+	const oldPlayerOvrMeanStdStale = local.playerOvrMeanStdStale;
+
+	try {
+		g.setWithoutSavingToDB("season", options.season);
+		g.setWithoutSavingToDB("numActiveTeams", 2);
+		local.playerOvrMean = 48;
+		local.playerOvrStd = 10;
+		local.playerOvrMeanStdStale = false;
+		for (const p of players) {
+			await player.develop(p, 0);
+			await player.updateValues(p);
+		}
+	} finally {
+		if (options.preservePlayerOvrContext) {
+			g.setWithoutSavingToDB("season", oldSeason);
+			g.setWithoutSavingToDB("numActiveTeams", oldNumActiveTeams);
+			local.playerOvrMean = oldPlayerOvrMean;
+			local.playerOvrStd = oldPlayerOvrStd;
+			local.playerOvrMeanStdStale = oldPlayerOvrMeanStdStale;
+		}
 	}
 
 	const playersByTid = Map.groupBy(players, (t) => t.tid);

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -26,6 +26,7 @@ if (process.env.NODE_ENV === "development") {
 
 export type WorkerAPICategory =
 	| "actions"
+	| "eightyTwoZeroDraft"
 	| "exhibitionGame"
 	| "leagueFileUpload"
 	| "main"

--- a/src/worker/util/local.ts
+++ b/src/worker/util/local.ts
@@ -5,6 +5,7 @@ const defaultLocal: Local = {
 	autoPlayUntil: undefined,
 	autoSave: true,
 	email: undefined,
+	eightyTwoZeroDraft: undefined,
 	exhibitionGamePlayers: undefined,
 	fantasyDraftResults: [],
 	goldUntil: Infinity, // Default is to assume Gold, until told otherwise by server
@@ -30,6 +31,7 @@ const local: Local & {
 	autoPlayUntil: defaultLocal.autoPlayUntil,
 	autoSave: defaultLocal.autoSave,
 	email: defaultLocal.email,
+	eightyTwoZeroDraft: defaultLocal.eightyTwoZeroDraft,
 	exhibitionGamePlayers: defaultLocal.exhibitionGamePlayers,
 	fantasyDraftResults: defaultLocal.fantasyDraftResults,
 	goldUntil: defaultLocal.goldUntil,
@@ -53,6 +55,7 @@ const local: Local & {
 		// These variables will be reset if the user switches leagues
 		local.autoPlayUntil = defaultLocal.autoPlayUntil;
 		local.autoSave = defaultLocal.autoSave;
+		local.eightyTwoZeroDraft = defaultLocal.eightyTwoZeroDraft;
 		local.exhibitionGamePlayers = defaultLocal.exhibitionGamePlayers;
 		local.fantasyDraftResults = defaultLocal.fantasyDraftResults;
 		local.leagueLoaded = defaultLocal.leagueLoaded;

--- a/src/worker/views/eightyTwoZeroDraft.ts
+++ b/src/worker/views/eightyTwoZeroDraft.ts
@@ -1,5 +1,6 @@
 import { PHASE, REAL_PLAYERS_INFO } from "../../common/constants.ts";
 import type { Phase } from "../../common/types.ts";
+import { bySport } from "../../common/sportFunctions.ts";
 import { g, local } from "../util/index.ts";
 import { getRealTeamInfo } from "./newLeague.ts";
 
@@ -19,6 +20,12 @@ const getActiveDraftErrorMessage = (phase: Phase) => {
 
 const updateEightyTwoZeroDraft = async () => {
 	const draft = local.eightyTwoZeroDraft;
+	const stats = bySport({
+		baseball: ["gp", "keyStats", "war"],
+		basketball: ["gp", "min", "pts", "trb", "ast", "per", "ws"],
+		football: ["gp", "keyStats", "av"],
+		hockey: ["gp", "keyStats", "ops", "dps", "ps"],
+	});
 
 	return {
 		activeDraftErrorMessage: getActiveDraftErrorMessage(g.get("phase")),
@@ -26,6 +33,7 @@ const updateEightyTwoZeroDraft = async () => {
 		loading: false,
 		realTeamInfo: await getRealTeamInfo(),
 		realPlayers: REAL_PLAYERS_INFO !== undefined,
+		stats,
 		started: draft !== undefined,
 		...(draft ?? {
 			currentTeam: undefined,

--- a/src/worker/views/eightyTwoZeroDraft.ts
+++ b/src/worker/views/eightyTwoZeroDraft.ts
@@ -1,11 +1,27 @@
-import { REAL_PLAYERS_INFO } from "../../common/constants.ts";
+import { PHASE, REAL_PLAYERS_INFO } from "../../common/constants.ts";
+import type { Phase } from "../../common/types.ts";
 import { g, local } from "../util/index.ts";
 import { getRealTeamInfo } from "./newLeague.ts";
+
+const getActiveDraftErrorMessage = (phase: Phase) => {
+	if (phase === PHASE.DRAFT) {
+		return "You can't start an 82-0 Draft while a regular draft is already in progress.";
+	}
+
+	if (phase === PHASE.FANTASY_DRAFT) {
+		return "You can't start an 82-0 Draft while a fantasy draft is already in progress.";
+	}
+
+	if (phase === PHASE.EXPANSION_DRAFT) {
+		return "You can't start an 82-0 Draft while an expansion draft is already in progress.";
+	}
+};
 
 const updateEightyTwoZeroDraft = async () => {
 	const draft = local.eightyTwoZeroDraft;
 
 	return {
+		activeDraftErrorMessage: getActiveDraftErrorMessage(g.get("phase")),
 		godMode: g.get("godMode"),
 		loading: false,
 		realTeamInfo: await getRealTeamInfo(),

--- a/src/worker/views/eightyTwoZeroDraft.ts
+++ b/src/worker/views/eightyTwoZeroDraft.ts
@@ -1,0 +1,22 @@
+import { REAL_PLAYERS_INFO } from "../../common/constants.ts";
+import { g, local } from "../util/index.ts";
+import { getRealTeamInfo } from "./newLeague.ts";
+
+const updateEightyTwoZeroDraft = async () => {
+	const draft = local.eightyTwoZeroDraft;
+
+	return {
+		godMode: g.get("godMode"),
+		loading: false,
+		realTeamInfo: await getRealTeamInfo(),
+		realPlayers: REAL_PLAYERS_INFO !== undefined,
+		started: draft !== undefined,
+		...(draft ?? {
+			currentTeam: undefined,
+			picks: [],
+			round: 1,
+		}),
+	};
+};
+
+export default updateEightyTwoZeroDraft;

--- a/src/worker/views/index.ts
+++ b/src/worker/views/index.ts
@@ -26,6 +26,7 @@ export { default as draftLottery } from "./draftLottery.ts";
 export { default as draftPicks } from "./draftPicks.ts";
 export { default as draftScouting } from "./draftScouting.ts";
 export { default as draftTeamHistory } from "./draftTeamHistory.ts";
+export { default as eightyTwoZeroDraft } from "./eightyTwoZeroDraft.ts";
 export { default as editAwards } from "./editAwards.ts";
 export { default as exhibition } from "./exhibition.ts";
 export { default as exhibitionGame } from "./exhibitionGame.ts";


### PR DESCRIPTION
## Summary

Adds an "82-0 Draft" entry next to Fantasy Draft in the Tools menu, available in God Mode in basketball leagues. Each of 12 rounds presents one random real historical team (1947-2026) and you draft one player from it. Every round locks one more of the presented team's top players, so round 4 locks the top 3 and late rounds force deep-bench picks. After 12 picks, finalizing deletes your current roster and replaces it with your selections.

## Why this matters

Implements the 82-0 Draft mode as you described it, modeled on 82-0.com's roster-building game. Team/player fetching reuses the real-rosters path that exhibition games and getRandomTeams already use, and in-progress draft state lives in transient worker memory (local.ts), so nothing touches IndexedDB until finalize.

## Demo

Demo: full 12-round draft and finalize in a dev league.

![demo](https://raw.githubusercontent.com/mvanhorn/zengm/evidence-assets/82-0-draft-demo.gif)

## Changes

A few decisions you may want to weigh in on:

- The same real player (srID) can't be drafted twice across rounds, but drafting a player who is already active in the league (real-players leagues) is allowed, so clones are possible there.
- Random draws re-roll until the presented team has at least one pickable player (1940s-60s playoff rosters run 9-10 players, which would dead-end late rounds). Retry cap of 20 draws, then it falls back to capping the locked count at roster size - 1.
- The menu item sits directly after Fantasy Draft, which breaks the alphabetical ordering of the Tools section. Easy to move if you'd rather keep the sort.
- Finalized picks follow the importPlayers cross-era pattern: fresh pids, born/draft years shifted so players arrive at their historical age, historical stats dropped, minimum contracts expiring next season or later.
- Starting is blocked during regular/fantasy/expansion draft phases, mirroring the Fantasy Draft guard.
- Fetching a historical season mid-league snapshots and restores g.season/numActiveTeams and the playerOvr fields that addSeasonInfoToTeams mutates, so live league state is untouched between rounds.

## Testing

- Unit tests for the lock-count, duplicate-srID, and pickability helpers (src/worker/api/eightyTwoZeroDraftHelpers.test.ts)
- pnpm lint and pnpm test pass
- Played a full 12-round draft plus finalize in a dev league (GIF above); verified the replaced roster, contracts, and that cancel/refresh leave no orphaned state
