### PR TITLE
Show salary on historical roster view

### DIFF
--- a/src/ui/views/Roster/index.tsx
+++ b/src/ui/views/Roster/index.tsx
@@ -17,6 +17,7 @@ import type {
 	View,
 } from "../../../common/types.ts";
 import { wrappedContract } from "../../components/contract.tsx";
+import { wrappedCurrency } from "../../components/wrappedCurrency.ts";
 import type {
 	DataTableRow,
 	SortBy,
@@ -165,7 +166,7 @@ const Roster = ({
 			"Age",
 			"Ovr",
 			"Pot",
-			...(season === currentSeason ? ["Contract"] : []),
+			season === currentSeason ? "Contract" : "Salary",
 			"stat:yearsWithTeam",
 			"Country",
 			...stats.map((stat) => `stat:${stat}`),
@@ -308,7 +309,9 @@ const Roster = ({
 				showRatings
 					? wrappedRatingWithChange(p.ratings.pot, p.ratings.dpot)
 					: null,
-				...(season === currentSeason ? [wrappedContract(p)] : []),
+				season === currentSeason
+					? wrappedContract(p)
+					: wrappedCurrency(p.contract.amount, "M"),
 				playoffs === "playoffs" ? null : p.stats.yearsWithTeam,
 				{
 					value: (


### PR DESCRIPTION
The roster page hides the salary/contract column entirely when viewing a past season. Show a "Salary" column instead of "Contract" for historical seasons, using the same data the worker already computes (`p.contract.amount` resolves to that season's actual salary via `getSalary()` when viewing a non-current season).