### PR TITLE
Show career WS on retirements

### DIFF
--- a/src/ui/components/RetiredPlayers.tsx
+++ b/src/ui/components/RetiredPlayers.tsx
@@ -12,6 +12,7 @@ export const RetiredPlayers = ({
 }: {
 	retiredPlayers: {
 		age: number;
+		careerWs?: number;
 		hof: boolean;
 		name: string;
 		pid: number;
@@ -61,6 +62,9 @@ export const RetiredPlayers = ({
 							</>
 						) : null}
 						age: {p.age}
+						{p.careerWs != null
+							? `, ${helpers.roundStat(p.careerWs, "ws")} WS`
+							: null}
 						{p.hof ? (
 							<>
 								;{" "}

--- a/src/worker/views/history.ts
+++ b/src/worker/views/history.ts
@@ -107,6 +107,28 @@ const updateHistory = async (
 			stats: ["tid", "abbrev"],
 			showNoStats: true,
 		});
+
+		const careerWsByPid: Record<number, number> = {};
+		const wsStats = bySport({
+			basketball: ["ws"],
+			baseball: [],
+			football: [],
+			hockey: [],
+		});
+		if (wsStats.length > 0) {
+			const retiredPlayersCareer = await idb.getCopies.playersPlus(
+				retiredPlayersAll,
+				{
+					attrs: ["pid"],
+					stats: wsStats,
+					showNoStats: true,
+				},
+			);
+			for (const p of retiredPlayersCareer) {
+				careerWsByPid[p.pid] = p.careerStats.ws ?? 0;
+			}
+		}
+
 		retiredPlayers.sort((a, b) => b.age - a.age);
 
 		// Get champs
@@ -121,7 +143,10 @@ const updateHistory = async (
 			champ,
 			confs: g.get("confs", season),
 			invalidSeason: false as const,
-			retiredPlayers,
+			retiredPlayers: retiredPlayers.map((p) => ({
+				...p,
+				careerWs: careerWsByPid[p.pid],
+			})),
 			season,
 		};
 	}


### PR DESCRIPTION
## Summary
- On the Season Summary page, each retired basketball player now shows their career win shares next to their age
- Basketball only — guarded by `bySport`, no change for football/baseball/hockey
- Career total WS fetched via a second `playersPlus` call (without season filter) and merged by pid

## Test plan
- [ ] Simulate a few seasons in a basketball league and check the Season Summary retired players list shows WS values
- [ ] Confirm football/baseball/hockey season summaries are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)