### PR TITLE
feat: add Dynasty 6 achievement (36 championships in 45 years)

### DIFF
--- a/src/worker/util/achievements.test.ts
+++ b/src/worker/util/achievements.test.ts
@@ -221,6 +221,70 @@ describe("checkAchievement", () => {
 		});
 	});
 
+	describe("dynasty_6", () => {
+		// Self-contained: builds its own 45-season window and cleans up after,
+		// rather than coupling to the cumulative state in the "dynasty*" block.
+		afterAll(async () => {
+			const teamSeasons = await idb.cache.teamSeasons.indexGetAll(
+				"teamSeasonsByTidSeason",
+				[[g.get("userTid")], [g.get("userTid"), "Z"]],
+			);
+			for (const teamSeason of teamSeasons) {
+				if (teamSeason.season > g.get("season")) {
+					await idb.cache.teamSeasons.delete(teamSeason.rid);
+				}
+			}
+		});
+
+		// Set the base season (g.season) to a known non-championship state so the
+		// 45-season trailing window is deterministic.
+		const resetBaseSeason = async () => {
+			const teamSeason = await idb.cache.teamSeasons.indexGet(
+				"teamSeasonsByTidSeason",
+				[g.get("userTid"), g.get("season")],
+			);
+			assert(teamSeason);
+			teamSeason.playoffRoundsWon = 0;
+			await idb.cache.teamSeasons.put(teamSeason);
+		};
+
+		test("award dynasty_6 (and dynasty_5) for 36 titles in 45 seasons", async () => {
+			await resetBaseSeason();
+
+			// 44 added seasons + the base season = 45 total in the trailing window.
+			// Oldest 9 (incl. base) are non-championships, most recent 36 are titles.
+			const extraSeasons: Partial<TeamSeason>[] = [];
+			for (let i = 0; i < 44; i++) {
+				// First 8 added seasons non-championships, remaining 36 championships.
+				extraSeasons.push({ playoffRoundsWon: i < 8 ? 0 : 4 });
+			}
+			await addExtraSeasons(g.get("userTid"), g.get("season"), extraSeasons);
+
+			let awarded = await get("dynasty_6").check();
+			assert.strictEqual(awarded, true);
+
+			// The 36 titles are the most recent seasons, so the trailing 30-season
+			// window is all championships -> dynasty_5 still awards (no regression).
+			awarded = await get("dynasty_5").check();
+			assert.strictEqual(awarded, true);
+		});
+
+		test("do not award dynasty_6 for only 35 titles in 45 seasons", async () => {
+			// Flip the oldest championship season (g.season + 9) to a non-title,
+			// dropping the count in the window from 36 to 35.
+			const teamSeason = await idb.cache.teamSeasons.indexGet(
+				"teamSeasonsByTidSeason",
+				[g.get("userTid"), g.get("season") + 9],
+			);
+			assert(teamSeason);
+			teamSeason.playoffRoundsWon = 0;
+			await idb.cache.teamSeasons.put(teamSeason);
+
+			const awarded = await get("dynasty_6").check();
+			assert.strictEqual(awarded, false);
+		});
+	});
+
 	describe("moneyball*", () => {
 		test("award moneyball and moneyball_2 for title with payroll <= half salary cap", async () => {
 			const teamSeason = await idb.cache.teamSeasons.indexGet(

--- a/src/worker/util/achievements.ts
+++ b/src/worker/util/achievements.ts
@@ -561,6 +561,24 @@ const achievements: Achievement[] = [
 		when: "afterPlayoffs",
 	},
 	{
+		slug: "dynasty_6",
+		name: "Dynasty 6",
+		desc: bySport({
+			basketball: "Win 36 championships in 45 years.",
+			default: "Win 30 championships in 45 years.",
+		}),
+		category: "Multiple Seasons",
+
+		check() {
+			return bySport({
+				basketball: checkDynasty(36, 45),
+				default: checkDynasty(30, 45),
+			});
+		},
+
+		when: "afterPlayoffs",
+	},
+	{
 		slug: "break_the_curse",
 		name: "Break The Curse",
 		desc: "Win a championship after going 108+ seasons without winning one.",


### PR DESCRIPTION
Adds a sixth tier to the Dynasty achievement ladder, which currently tops out at Dynasty 5 (24 championships in 30 years). Players who've earned Dynasty 5 have no further dynasty milestone to chase, so this gives long-running saves a new end-game target.

**Dynasty 6** — Win **36 championships in 45 years** (basketball), `default` **30 in 45**.

The thresholds follow the existing curve:

| Tier | Basketball | default |
|------|-----------|---------|
| Dynasty | 6 / 8 | 3 / 5 |
| Dynasty 2 | 8 in a row | 5 in a row |
| Dynasty 3 | 11 / 13 | 10 / 15 |
| Dynasty 4 | 16 / 20 | 13 / 20 |
| Dynasty 5 | 24 / 30 | 20 / 30 |
| **Dynasty 6** | **36 / 45** | **30 / 45** |

That keeps basketball around its ~0.8 titles/year rate and the default ladder around ~0.67, over a 45-year window. The numbers are just a proposal — easy to tune if you'd prefer something different.

Implementation is one new object in `src/worker/util/achievements.ts` reusing the existing `checkDynasty(titles, years)` helper, plus self-contained tests in `achievements.test.ts`. No helper, type, or UI changes needed (the achievements list renders dynamically).

One thing worth flagging: a brand-new slug (`dynasty_6`) won't have a cross-account earned count until the ZenGM account server recognizes it, since that lives outside this repo.

`node --run test` and `node --run lint` pass locally. CLA has been emailed.
