### PR TITLE
Add option to disable notification popups

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -989,6 +989,7 @@ export type Option = {
 export type Options = {
 	fullNames?: boolean;
 	phaseChangeRedirects: Phase[];
+	suppressNotifications?: boolean;
 	units?: "metric" | "us";
 };
 
@@ -1043,6 +1044,7 @@ export type LocalStateUI = {
 	popup: boolean;
 	showLeagueTopBar: boolean;
 	showNagModal: boolean;
+	suppressNotifications: boolean;
 	sidebarOpen: boolean;
 	statusText: string;
 	units: "metric" | "us";

--- a/src/ui/util/local.ts
+++ b/src/ui/util/local.ts
@@ -90,6 +90,7 @@ const useLocalRaw = createWithEqualityFn<LocalStateWithActions>(
 		season: 0,
 		showLeagueTopBar: initialShowLeagueTopBar,
 		showNagModal: false,
+		suppressNotifications: false,
 		sidebarOpen: initialSidebarOpen,
 		spectator: false,
 		startingSeason: 0,

--- a/src/ui/util/logEvent.ts
+++ b/src/ui/util/logEvent.ts
@@ -2,7 +2,6 @@ import { createLogger } from "../../common/createLogger.ts";
 import { local } from "./local.ts";
 import type { LogEventShowOptions } from "../../common/types.ts";
 import { notify } from "./notify.ts";
-import { safeLocalStorage } from "./safeLocalStorage.ts";
 import { toWorker } from "./toWorker.ts";
 
 const saveEvent = () => {
@@ -45,7 +44,7 @@ export const showEvent = ({
 		type !== "error" &&
 		type !== "success" &&
 		type !== "changes" &&
-		safeLocalStorage.getItem("bbgmSuppressNotifications") === "true"
+		local.getState().suppressNotifications
 	) {
 		return;
 	}

--- a/src/ui/util/logEvent.ts
+++ b/src/ui/util/logEvent.ts
@@ -2,6 +2,7 @@ import { createLogger } from "../../common/createLogger.ts";
 import { local } from "./local.ts";
 import type { LogEventShowOptions } from "../../common/types.ts";
 import { notify } from "./notify.ts";
+import { safeLocalStorage } from "./safeLocalStorage.ts";
 import { toWorker } from "./toWorker.ts";
 
 const saveEvent = () => {
@@ -37,6 +38,16 @@ export const showEvent = ({
 
 	if (persistent && extraClass === undefined) {
 		extraClass = "notification-danger";
+	}
+
+	if (
+		!persistent &&
+		type !== "error" &&
+		type !== "success" &&
+		type !== "changes" &&
+		safeLocalStorage.getItem("bbgmSuppressNotifications") === "true"
+	) {
+		return;
 	}
 
 	let showNotification = true;

--- a/src/ui/views/GlobalSettings/index.tsx
+++ b/src/ui/views/GlobalSettings/index.tsx
@@ -40,11 +40,15 @@ const GlobalSettings = (props: View<"globalSettings">) => {
 
 		const fullNames = props.fullNames ? "always" : ("abbrev-small" as const);
 
+		const suppressNotifications =
+			safeLocalStorage.getItem("bbgmSuppressNotifications") === "true";
+
 		return {
 			fullNames,
 			phaseChangeRedirects: props.phaseChangeRedirects,
 			realPlayerPhotos: props.realPlayerPhotos,
 			realTeamInfo: props.realTeamInfo,
+			suppressNotifications,
 			theme,
 			units,
 		};
@@ -71,6 +75,10 @@ const GlobalSettings = (props: View<"globalSettings">) => {
 		} else {
 			safeLocalStorage.setItem("theme", state.theme);
 		}
+		safeLocalStorage.setItem(
+			"bbgmSuppressNotifications",
+			String(state.suppressNotifications),
+		);
 		if (window.themeCSSLink) {
 			window.themeCSSLink.href = window.getThemeFilename(window.getTheme());
 		}
@@ -248,6 +256,30 @@ const GlobalSettings = (props: View<"globalSettings">) => {
 					<div className="col-sm-3 col-6 mb-3">
 						<label className="form-label">Persistent Storage</label>
 						<Storage />
+					</div>
+					<div className="col-sm-3 col-6 mb-3">
+						<label className="form-label">Notifications</label>
+						<div className="form-check">
+							<input
+								className="form-check-input"
+								type="checkbox"
+								id="options-suppressNotifications"
+								checked={state.suppressNotifications}
+								onChange={() => {
+									setState({
+										...state,
+										suppressNotifications: !state.suppressNotifications,
+									});
+									setDirty(true);
+								}}
+							/>
+							<label
+								className="form-check-label"
+								htmlFor="options-suppressNotifications"
+							>
+								Disable notification popups
+							</label>
+						</div>
 					</div>
 				</div>
 

--- a/src/ui/views/GlobalSettings/index.tsx
+++ b/src/ui/views/GlobalSettings/index.tsx
@@ -40,15 +40,12 @@ const GlobalSettings = (props: View<"globalSettings">) => {
 
 		const fullNames = props.fullNames ? "always" : ("abbrev-small" as const);
 
-		const suppressNotifications =
-			safeLocalStorage.getItem("bbgmSuppressNotifications") === "true";
-
 		return {
 			fullNames,
 			phaseChangeRedirects: props.phaseChangeRedirects,
 			realPlayerPhotos: props.realPlayerPhotos,
 			realTeamInfo: props.realTeamInfo,
-			suppressNotifications,
+			suppressNotifications: props.suppressNotifications,
 			theme,
 			units,
 		};
@@ -75,10 +72,6 @@ const GlobalSettings = (props: View<"globalSettings">) => {
 		} else {
 			safeLocalStorage.setItem("theme", state.theme);
 		}
-		safeLocalStorage.setItem(
-			"bbgmSuppressNotifications",
-			String(state.suppressNotifications),
-		);
 		if (window.themeCSSLink) {
 			window.themeCSSLink.href = window.getThemeFilename(window.getTheme());
 		}
@@ -90,6 +83,7 @@ const GlobalSettings = (props: View<"globalSettings">) => {
 				phaseChangeRedirects: state.phaseChangeRedirects,
 				realPlayerPhotos: state.realPlayerPhotos,
 				realTeamInfo: state.realTeamInfo,
+				suppressNotifications: state.suppressNotifications,
 				units,
 			});
 			logEvent({

--- a/src/worker/api/index.ts
+++ b/src/worker/api/index.ts
@@ -2875,7 +2875,14 @@ const init = async (inputEnv: Env, conditions: Conditions) => {
 	)) as KeyboardShortcutsLocal;
 	await toUI(
 		"updateLocal",
-		[{ fullNames: options.fullNames, keyboardShortcuts, units: options.units }],
+		[
+			{
+				fullNames: options.fullNames,
+				keyboardShortcuts,
+				suppressNotifications: !!options.suppressNotifications,
+				units: options.units,
+			},
+		],
 		conditions,
 	);
 };
@@ -4144,13 +4151,18 @@ const updateOptions = async (
 			units: options.units,
 			fullNames: options.fullNames,
 			phaseChangeRedirects: options.phaseChangeRedirects,
+			suppressNotifications: options.suppressNotifications,
 		},
 		"options",
 	);
 	await attributesStore.put(realPlayerPhotos, "realPlayerPhotos");
 	await attributesStore.put(realTeamInfo, "realTeamInfo");
 	await toUI("updateLocal", [
-		{ units: options.units, fullNames: options.fullNames },
+		{
+			units: options.units,
+			fullNames: options.fullNames,
+			suppressNotifications: !!options.suppressNotifications,
+		},
 	]);
 	await toUI("realtimeUpdate", [["options"]]);
 };

--- a/src/worker/views/globalSettings.ts
+++ b/src/worker/views/globalSettings.ts
@@ -23,6 +23,7 @@ const updateOptions = async (inputs: unknown, updateEvents: UpdateEvents) => {
 			units: options.units,
 			fullNames: !!options.fullNames,
 			phaseChangeRedirects: options.phaseChangeRedirects,
+			suppressNotifications: !!options.suppressNotifications,
 		};
 	}
 };


### PR DESCRIPTION
Adds a checkbox in Global Settings to suppress non-critical notification popups. Errors, success confirmations, and persistent (red) notifications still show. Setting persists via localStorage.