### PR TITLE
Mark intentional fouls in play-by-play text

### DIFF
--- a/src/ui/util/processLiveGameEvents.basketball.tsx
+++ b/src/ui/util/processLiveGameEvents.basketball.tsx
@@ -234,7 +234,7 @@ export const getText = (
 		texts = [`${getName(event.pid)} missed a free throw`];
 	} else if (event.type === "pfNonShooting") {
 		texts = [
-			`Non-shooting foul on ${getName(event.pid)}${formatLiveGameStat(playersByPid[event.pid], "pf")}`,
+			`${event.intentional ? "Intentional" : "Non-shooting"} foul on ${getName(event.pid)}${formatLiveGameStat(playersByPid[event.pid], "pf")}`,
 		];
 	} else if (event.type === "pfBonus") {
 		texts = [

--- a/src/worker/core/GameSim.basketball/PlayByPlayLogger.ts
+++ b/src/worker/core/GameSim.basketball/PlayByPlayLogger.ts
@@ -70,7 +70,6 @@ type PlayByPlayEventInputNoScore =
 				| BlockType
 				| FgaType
 				| FgMissType
-				| "pfNonShooting"
 				| "drb"
 				| "orb"
 				| "foulOut"
@@ -79,6 +78,13 @@ type PlayByPlayEventInputNoScore =
 			t: TeamNum;
 			pid: number;
 			clock: number;
+	  }
+	| {
+			type: "pfNonShooting";
+			t: TeamNum;
+			pid: number;
+			clock: number;
+			intentional: boolean;
 	  }
 	| {
 			type: "jumpBall";

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -1643,7 +1643,11 @@ class GameSim extends GameSimBase {
 			if (inBonus) {
 				this.doPf({ t: this.d, type: "pfBonus", shooter });
 			} else {
-				this.doPf({ t: this.d, type: "pfNonShooting" });
+				this.doPf({
+					t: this.d,
+					type: "pfNonShooting",
+					intentional: clockFactor === "intentionalFoul",
+				});
 			}
 
 			if (inBonus) {
@@ -2649,6 +2653,7 @@ class GameSim extends GameSimBase {
 					type: "pfNonShooting";
 					shooter?: undefined;
 					fouler?: PlayerGameSim;
+					intentional: boolean;
 			  }
 			| {
 					t: TeamNum;
@@ -2672,6 +2677,7 @@ class GameSim extends GameSimBase {
 				this.playByPlay.logEvent({
 					...baseLogInformation,
 					type: info.type,
+					intentional: info.intentional,
 				});
 			} else {
 				this.playByPlay.logEvent({


### PR DESCRIPTION
## Summary
Play-by-play now says "Intentional foul" instead of "Non-shooting foul" for clock-management fouls late in games, per the TODO item.