### PR TITLE
Optimize basketball simulation and batch advanced-stat cache writes

### DIFF
--- a/src/worker/core/GameSim.basketball/PlayByPlayLogger.ts
+++ b/src/worker/core/GameSim.basketball/PlayByPlayLogger.ts
@@ -226,6 +226,10 @@ class BasketballPlayByPlayLogger extends PlayByPlayLoggerBase<PlayByPlayEventOut
 	}
 
 	logEvent(event: PlayByPlayEventInput) {
+		if (!this.active) {
+			return;
+		}
+
 		if (event.type === "period" || event.type === "overtime") {
 			this.period = event.period;
 		}
@@ -235,13 +239,9 @@ class BasketballPlayByPlayLogger extends PlayByPlayLoggerBase<PlayByPlayEventOut
 				...event,
 				period: this.period,
 			};
-			if (this.active) {
-				this.playByPlay.push(event2);
-			}
+			this.playByPlay.push(event2);
 		} else {
-			if (this.active) {
-				this.playByPlay.push(event);
-			}
+			this.playByPlay.push(event);
 		}
 	}
 }

--- a/src/worker/core/GameSim.basketball/index.test.ts
+++ b/src/worker/core/GameSim.basketball/index.test.ts
@@ -1,0 +1,196 @@
+import { assert, beforeAll, test, vi } from "vitest";
+import { DEFAULT_LEVEL } from "../../../common/budgetLevels.ts";
+import { range } from "../../../common/utils.ts";
+import { resetCache, resetG } from "../../../test/helpers.ts";
+import { g, helpers } from "../../util/index.ts";
+import { player, team } from "../index.ts";
+import loadTeams from "../game/loadTeams.ts";
+import GameSim from "./index.ts";
+
+const assertClose = (actual: number, expected: number) => {
+	assert(
+		Math.abs(actual - expected) < 1e-10,
+		`Expected ${actual} to be close to ${expected}`,
+	);
+};
+
+const initGameSim = async (doPlayByPlay = false) => {
+	const teams = await loadTeams([0, 1], {});
+
+	return new GameSim({
+		gid: 0,
+		teams: [teams[0], teams[1]],
+		baseInjuryRate: 0,
+		doPlayByPlay,
+		homeCourtFactor: 1,
+		allStarGame: false,
+		neutralSite: true,
+	});
+};
+
+beforeAll(async () => {
+	resetG();
+	g.setWithoutSavingToDB("season", 2013);
+	const teamsDefault = helpers.getTeamsDefault().slice(0, 2);
+	await resetCache({
+		players: [
+			...range(15).map(() => player.generate(0, 25, 2010, true, DEFAULT_LEVEL)),
+			...range(15).map(() => player.generate(1, 25, 2010, true, DEFAULT_LEVEL)),
+		],
+		teams: teamsDefault.map(team.generate),
+		teamSeasons: teamsDefault.map((t) => team.genSeasonRow(t)),
+		teamStats: teamsDefault.map((t) => team.genStatsRow(t.tid)),
+	});
+});
+
+test("updates playing time, energy, team minutes, and play-by-play", async () => {
+	const game = await initGameSim(true);
+	game.playByPlay.playByPlay.length = 0;
+
+	for (const t of [0, 1] as const) {
+		game.team[t].stat.min = 0;
+		for (const p of game.team[t].player) {
+			p.stat.min = 0;
+			p.stat.courtTime = 0;
+			p.stat.benchTime = 0;
+			p.stat.energy = 0.5;
+		}
+	}
+
+	game.updatePlayingTime(60);
+
+	for (const t of [0, 1] as const) {
+		assertClose(game.team[t].stat.min, game.numPlayersOnCourt);
+
+		for (const p of game.team[t].player) {
+			if (game.playersOnCourt[t].includes(p)) {
+				assertClose(p.stat.min, 1);
+				assertClose(p.stat.courtTime, 1);
+				assertClose(p.stat.benchTime, 0);
+				assertClose(
+					p.stat.energy,
+					Math.max(
+						0,
+						0.5 - game.fatigueFactor * (1 - p.compositeRating.endurance),
+					),
+				);
+			} else {
+				assertClose(p.stat.min, 0);
+				assertClose(p.stat.courtTime, 0);
+				assertClose(p.stat.benchTime, 1);
+				assertClose(p.stat.energy, 0.594);
+			}
+		}
+	}
+
+	const events = game.playByPlay.playByPlay;
+	assert.strictEqual(events.length, 2 * game.numPlayersOnCourt);
+	assert(events.every((event) => event.type === "stat" && event.s === "min"));
+});
+
+test("updates team composites without changing the rating formula", async () => {
+	const game = await initGameSim();
+	game.synergyFactor = 0;
+	game.t = 5 * 60;
+	game.elamActive = false;
+	game.team[0].stat.pts = 100;
+	game.team[1].stat.pts = 80;
+	game.team[0].stat.ptsQtrs = [25, 25, 25, 25];
+	game.team[1].stat.ptsQtrs = [20, 20, 20, 20];
+
+	const ratings = [
+		"dribbling",
+		"passing",
+		"rebounding",
+		"defense",
+		"defensePerimeter",
+		"blocking",
+	] as const;
+	for (const t of [0, 1] as const) {
+		for (const [i, p] of game.playersOnCourt[t].entries()) {
+			p.stat.energy = 0.4 + 0.1 * i;
+			p.stat.pf = i;
+			for (const [j, rating] of ratings.entries()) {
+				p.compositeRating[rating] = 0.1 + 0.02 * i + 0.01 * j + 0.03 * t;
+			}
+		}
+	}
+
+	const foulLimit = game.getFoulTroubleLimit();
+	const expected = ratings.map((rating) =>
+		([0, 1] as const).map((t) => {
+			const oppT = t === 0 ? 1 : 0;
+			const diff = game.team[t].stat.pts - game.team[oppT].stat.pts;
+			const perfFactor = 1 - 0.2 * Math.tanh(diff / 60);
+			let value = 0;
+			for (const p of game.playersOnCourt[t]) {
+				let foulLimitFactor = 1;
+				if (
+					rating === "defense" ||
+					rating === "defensePerimeter" ||
+					rating === "blocking"
+				) {
+					if (p.stat.pf === foulLimit) {
+						foulLimitFactor = 0.9;
+					} else if (p.stat.pf > foulLimit) {
+						foulLimitFactor = 0.75;
+					}
+				}
+				value +=
+					p.compositeRating[rating] *
+					game.fatigue(p.stat.energy) *
+					perfFactor *
+					foulLimitFactor;
+			}
+			return value / 5;
+		}),
+	);
+
+	game.updateTeamCompositeRatings();
+
+	for (const [r, rating] of ratings.entries()) {
+		for (const t of [0, 1] as const) {
+			assertClose(game.team[t].compositeRating[rating], expected[r]![t]!);
+		}
+	}
+});
+
+test("selects players at both ends of the weighted range", async () => {
+	const game = await initGameSim();
+	for (const [i, p] of game.playersOnCourt[0].entries()) {
+		p.stat.energy = 1;
+		p.compositeRating.usage = 0.1 + 0.1 * i;
+	}
+
+	const random = vi.spyOn(Math, "random");
+	try {
+		random.mockReturnValue(0);
+		assert.strictEqual(
+			game.pickPlayer("usage", 0, 1),
+			game.playersOnCourt[0][0],
+		);
+
+		random.mockReturnValue(1 - Number.EPSILON);
+		assert.strictEqual(
+			game.pickPlayer("usage", 0, 1),
+			game.playersOnCourt[0].at(-1),
+		);
+	} finally {
+		random.mockRestore();
+	}
+});
+
+test("simulates a complete game with internally consistent minutes", async () => {
+	const game = await initGameSim();
+	const result = game.run();
+
+	for (const t of [0, 1] as const) {
+		const playerMinutes = result.team[t].player.reduce(
+			(sum, p) => sum + p.stat.min,
+			0,
+		);
+		assertClose(playerMinutes, result.team[t].stat.min);
+		assert(Number.isInteger(result.team[t].stat.pts));
+		assert(result.team[t].stat.pts >= 0);
+	}
+});

--- a/src/worker/core/GameSim.basketball/index.ts
+++ b/src/worker/core/GameSim.basketball/index.ts
@@ -152,6 +152,14 @@ class GameSim extends GameSimBase {
 
 	playersOnCourt: [PlayerGameSim[], PlayerGameSim[]];
 
+	playerSelectionRatios: number[];
+
+	// Individual skill contributions are constant between home-court adjustments.
+	synergySkills = new WeakMap<
+		PlayerGameSim,
+		Record<"3" | "A" | "B" | "Di" | "Dp" | "Po" | "Ps" | "R", number>
+	>();
+
 	t: number;
 
 	numPeriods: number;
@@ -248,6 +256,7 @@ class GameSim extends GameSimBase {
 			this.team[0].player.slice(0, this.numPlayersOnCourt),
 			this.team[1].player.slice(0, this.numPlayersOnCourt),
 		];
+		this.playerSelectionRatios = new Array(this.numPlayersOnCourt);
 
 		this.updatePlayersOnCourt({
 			recordStarters: true,
@@ -300,6 +309,9 @@ class GameSim extends GameSimBase {
 	 *
 	 */
 	homeCourtAdvantage(homeCourtFactor: number) {
+		// The constructor calculates initial synergy before applying home court.
+		// Invalidate here so subsequent substitutions use the adjusted ratings.
+		this.synergySkills = new WeakMap();
 		const homeCourtModifier =
 			homeCourtFactor *
 			helpers.bound(1 + g.get("homeCourtAdvantage") / 100, 0.01, Infinity);
@@ -1167,41 +1179,29 @@ class GameSim extends GameSimBase {
 			for (let i = 0; i < this.numPlayersOnCourt; i++) {
 				const p = this.playersOnCourt[t][i]!;
 
-				// 1 / (1 + e^-(15 * (x - 0.61))) from 0 to 1
-				// 0.61 is not always used - keep in sync with skills.js!
-
-				skillsCount["3"] += helpers.sigmoid(
-					p.compositeRating.shootingThreePointer,
-					15,
-					0.59,
-				);
-				skillsCount.A += helpers.sigmoid(
-					p.compositeRating.athleticism,
-					15,
-					0.63,
-				);
-				skillsCount.B += helpers.sigmoid(p.compositeRating.dribbling, 15, 0.68);
-				skillsCount.Di += helpers.sigmoid(
-					p.compositeRating.defenseInterior,
-					15,
-					0.57,
-				);
-				skillsCount.Dp += helpers.sigmoid(
-					p.compositeRating.defensePerimeter,
-					15,
-					0.61,
-				);
-				skillsCount.Po += helpers.sigmoid(
-					p.compositeRating.shootingLowPost,
-					15,
-					0.61,
-				);
-				skillsCount.Ps += helpers.sigmoid(p.compositeRating.passing, 15, 0.63);
-				skillsCount.R += helpers.sigmoid(
-					p.compositeRating.rebounding,
-					15,
-					0.61,
-				);
+				let skills = this.synergySkills.get(p);
+				if (!skills) {
+					const r = p.compositeRating;
+					skills = {
+						"3": helpers.sigmoid(r.shootingThreePointer, 15, 0.59),
+						A: helpers.sigmoid(r.athleticism, 15, 0.63),
+						B: helpers.sigmoid(r.dribbling, 15, 0.68),
+						Di: helpers.sigmoid(r.defenseInterior, 15, 0.57),
+						Dp: helpers.sigmoid(r.defensePerimeter, 15, 0.61),
+						Po: helpers.sigmoid(r.shootingLowPost, 15, 0.61),
+						Ps: helpers.sigmoid(r.passing, 15, 0.63),
+						R: helpers.sigmoid(r.rebounding, 15, 0.61),
+					};
+					this.synergySkills.set(p, skills);
+				}
+				skillsCount["3"] += skills["3"];
+				skillsCount.A += skills.A;
+				skillsCount.B += skills.B;
+				skillsCount.Di += skills.Di;
+				skillsCount.Dp += skills.Dp;
+				skillsCount.Po += skills.Po;
+				skillsCount.Ps += skills.Ps;
+				skillsCount.R += skills.R;
 			}
 
 			// Base offensive synergy
@@ -1260,70 +1260,43 @@ class GameSim extends GameSimBase {
 	 * This should be called once every possession, after this.updatePlayersOnCourt and this.updateSynergy as they influence output, to update the team composite ratings based on the players currently on the court.
 	 */
 	updateTeamCompositeRatings() {
-		// Only update ones that are actually used
-		const toUpdate = [
-			"dribbling",
-			"passing",
-			"rebounding",
-			"defense",
-			"defensePerimeter",
-			"blocking",
-		];
-
 		const foulLimit = this.getFoulTroubleLimit();
-
-		// Scale composite ratings
 		for (const t of teamNums) {
 			const oppT = teamNums[1 - t]!;
 			const diff = this.team[t].stat.pts - this.team[oppT].stat.pts;
-
 			const perfFactor = 1 - 0.2 * Math.tanh(diff / 60);
-
-			for (const rating of toUpdate) {
-				this.team[t].compositeRating[rating] = 0;
-
-				for (let i = 0; i < this.numPlayersOnCourt; i++) {
-					const p = this.playersOnCourt[t][i]!;
-
-					let foulLimitFactor = 1;
-					if (
-						rating === "defense" ||
-						rating === "defensePerimeter" ||
-						rating === "blocking"
-					) {
-						const pf = p.stat.pf;
-						if (pf === foulLimit) {
-							foulLimitFactor *= 0.9;
-						} else if (pf > foulLimit) {
-							foulLimitFactor *= 0.75;
-						}
-					}
-
-					this.team[t].compositeRating[rating] +=
-						p.compositeRating[rating] *
-						this.fatigue(p.stat.energy) *
-						perfFactor *
-						foulLimitFactor;
-				}
-
-				this.team[t].compositeRating[rating] /= 5;
+			let dribbling = 0;
+			let passing = 0;
+			let rebounding = 0;
+			let defense = 0;
+			let defensePerimeter = 0;
+			let blocking = 0;
+			for (const p of this.playersOnCourt[t]) {
+				const ratings = p.compositeRating;
+				const fatigue = this.fatigue(p.stat.energy);
+				const pf = p.stat.pf;
+				const foulFactor = pf === foulLimit ? 0.9 : pf > foulLimit ? 0.75 : 1;
+				// Preserve the multiplication and summation order for seeded games.
+				// Static property access also avoids six dynamic lookups per player.
+				dribbling += ratings.dribbling * fatigue * perfFactor;
+				passing += ratings.passing * fatigue * perfFactor;
+				rebounding += ratings.rebounding * fatigue * perfFactor;
+				defense += ratings.defense * fatigue * perfFactor * foulFactor;
+				defensePerimeter +=
+					ratings.defensePerimeter * fatigue * perfFactor * foulFactor;
+				blocking += ratings.blocking * fatigue * perfFactor * foulFactor;
 			}
-
-			this.team[t].compositeRating.dribbling +=
-				this.synergyFactor * this.team[t].synergy.off;
-			this.team[t].compositeRating.passing +=
-				this.synergyFactor * this.team[t].synergy.off;
-			this.team[t].compositeRating.rebounding +=
-				this.synergyFactor * this.team[t].synergy.reb;
-			this.team[t].compositeRating.defense +=
-				this.synergyFactor * this.team[t].synergy.def;
-			this.team[t].compositeRating.defensePerimeter +=
-				this.synergyFactor * this.team[t].synergy.def;
-			this.team[t].compositeRating.blocking +=
-				this.synergyFactor * this.team[t].synergy.def;
+			const ratings = this.team[t].compositeRating;
+			const synergy = this.team[t].synergy;
+			ratings.dribbling = dribbling / 5 + this.synergyFactor * synergy.off;
+			ratings.passing = passing / 5 + this.synergyFactor * synergy.off;
+			ratings.rebounding = rebounding / 5 + this.synergyFactor * synergy.reb;
+			ratings.defense = defense / 5 + this.synergyFactor * synergy.def;
+			ratings.defensePerimeter =
+				defensePerimeter / 5 + this.synergyFactor * synergy.def;
+			ratings.blocking = blocking / 5 + this.synergyFactor * synergy.def;
 		}
 	}
-
 	/**
 	 * Update playing time stats.
 	 *
@@ -1332,26 +1305,32 @@ class GameSim extends GameSimBase {
 	updatePlayingTime(possessionLength: number) {
 		const min = possessionLength / 60;
 		for (const t of teamNums) {
+			const playersOnCourt = this.playersOnCourt[t];
+
 			// Update minutes (overall, court, and bench)
 			for (const p of this.team[t].player) {
-				if (this.playersOnCourt[t].includes(p)) {
-					this.recordStat(t, p, "min", min);
-					this.recordStat(t, p, "courtTime", min);
+				if (playersOnCourt.includes(p)) {
+					// This is a very hot path. Do the equivalent of recordStat directly
+					// so court/bench bookkeeping does not repeatedly pass through all of
+					// recordStat's scoring and play-by-play branches.
+					p.stat.min += min;
+					this.team[t].stat.min += min;
+					if (this.playByPlay.active) {
+						this.playByPlay.logStat(t, p.id, "min", min);
+					}
+
+					p.stat.courtTime += min;
 
 					// This used to be 0.04. Increase more to lower PT
-					this.recordStat(
-						t,
-						p,
-						"energy",
-						-min * this.fatigueFactor * (1 - p.compositeRating.endurance),
-					);
+					p.stat.energy +=
+						-min * this.fatigueFactor * (1 - p.compositeRating.endurance);
 
 					if (p.stat.energy < 0) {
 						p.stat.energy = 0;
 					}
 				} else {
-					this.recordStat(t, p, "benchTime", min);
-					this.recordStat(t, p, "energy", min * 0.094);
+					p.stat.benchTime += min;
+					p.stat.energy += min * 0.094;
 
 					if (p.stat.energy > 1) {
 						p.stat.energy = 1;
@@ -2760,12 +2739,18 @@ class GameSim extends GameSimBase {
 	 * @param {number=} power Power that the composite rating is raised to after the components are linearly combined by  the weights and scaled from 0 to 1. This can be used to introduce nonlinearities, like making a certain stat more uniform (power < 1) or more unevenly distributed (power > 1) or making a composite rating an inverse (power = -1). Default value is 1.
 	 * @return {Array.<number>} Array of composite ratings of the players on the court for the given rating and team.
 	 */
-	ratingArray(rating: CompositeRating, t: TeamNum, power: number = 1) {
+	ratingArray(
+		rating: CompositeRating,
+		t: TeamNum,
+		power: number = 1,
+		array: number[] = new Array(this.numPlayersOnCourt),
+	) {
 		const foulLimit = rating === "fouling" ? this.getFoulTroubleLimit() : 0;
 		let total = 0;
 
 		// Scale composite ratings
-		const array = this.playersOnCourt[t].map((p, i) => {
+		for (let i = 0; i < this.numPlayersOnCourt; i++) {
+			const p = this.playersOnCourt[t][i]!;
 			let compositeRating = p.compositeRating[rating];
 
 			if (rating === "fouling") {
@@ -2781,10 +2766,9 @@ class GameSim extends GameSimBase {
 
 			const value = (compositeRating * this.fatigue(p.stat.energy)) ** power;
 
+			array[i] = value;
 			total += value;
-
-			return value;
-		});
+		}
 
 		// Set floor (5% of total)
 		const floor = 0.05 * total;
@@ -2804,7 +2788,12 @@ class GameSim extends GameSimBase {
 		power: number,
 		exempt?: PlayerGameSim,
 	) {
-		const ratios = this.ratingArray(rating, t, power);
+		const ratios = this.ratingArray(
+			rating,
+			t,
+			power,
+			this.playerSelectionRatios,
+		);
 		const playersOnCourt = this.playersOnCourt[t];
 
 		if (exempt !== undefined) {
@@ -2829,8 +2818,8 @@ class GameSim extends GameSimBase {
 
 		let runningSum = 0;
 
-		for (const [i, ratio] of ratios.entries()) {
-			runningSum += ratio;
+		for (let i = 0; i < this.numPlayersOnCourt; i++) {
+			runningSum += ratios[i]!;
 			if (rand < runningSum) {
 				return playersOnCourt[i]!;
 			}

--- a/src/worker/core/GameSim.basketball/performance.reference.ts
+++ b/src/worker/core/GameSim.basketball/performance.reference.ts
@@ -1,0 +1,187 @@
+// Pre-optimization methods retained only for regression tests and benchmarks.
+// Keep these independent of production refactors so seeded comparisons are useful.
+import { helpers } from "../../util/index.ts";
+import GameSim from "./index.ts";
+
+const teamNums = [0, 1] as const;
+const compositeRatingsToUpdate = [
+	"dribbling",
+	"passing",
+	"rebounding",
+	"defense",
+	"defensePerimeter",
+	"blocking",
+] as const;
+
+export default class ReferenceGameSim extends GameSim {
+	compositeFatigue = new Array<number>(this.numPlayersOnCourt);
+	compositeFoulFactor = new Array<number>(this.numPlayersOnCourt);
+	override updateTeamCompositeRatings() {
+		const foulLimit = this.getFoulTroubleLimit();
+
+		// Scale composite ratings
+		for (const t of teamNums) {
+			const oppT = teamNums[1 - t]!;
+			const diff = this.team[t].stat.pts - this.team[oppT].stat.pts;
+
+			const perfFactor = 1 - 0.2 * Math.tanh(diff / 60);
+			const playersOnCourt = this.playersOnCourt[t];
+
+			// These values do not change between ratings, so compute them once per
+			// player rather than six times per possession.
+			for (let i = 0; i < this.numPlayersOnCourt; i++) {
+				const p = playersOnCourt[i]!;
+				this.compositeFatigue[i] = this.fatigue(p.stat.energy);
+
+				const pf = p.stat.pf;
+				if (pf === foulLimit) {
+					this.compositeFoulFactor[i] = 0.9;
+				} else if (pf > foulLimit) {
+					this.compositeFoulFactor[i] = 0.75;
+				} else {
+					this.compositeFoulFactor[i] = 1;
+				}
+			}
+
+			for (const rating of compositeRatingsToUpdate) {
+				this.team[t].compositeRating[rating] = 0;
+				const isDefenseRating =
+					rating === "defense" ||
+					rating === "defensePerimeter" ||
+					rating === "blocking";
+
+				for (let i = 0; i < this.numPlayersOnCourt; i++) {
+					const p = playersOnCourt[i]!;
+					const foulLimitFactor = isDefenseRating
+						? this.compositeFoulFactor[i]!
+						: 1;
+
+					this.team[t].compositeRating[rating] +=
+						p.compositeRating[rating] *
+						this.compositeFatigue[i]! *
+						perfFactor *
+						foulLimitFactor;
+				}
+
+				this.team[t].compositeRating[rating] /= 5;
+			}
+
+			this.team[t].compositeRating.dribbling +=
+				this.synergyFactor * this.team[t].synergy.off;
+			this.team[t].compositeRating.passing +=
+				this.synergyFactor * this.team[t].synergy.off;
+			this.team[t].compositeRating.rebounding +=
+				this.synergyFactor * this.team[t].synergy.reb;
+			this.team[t].compositeRating.defense +=
+				this.synergyFactor * this.team[t].synergy.def;
+			this.team[t].compositeRating.defensePerimeter +=
+				this.synergyFactor * this.team[t].synergy.def;
+			this.team[t].compositeRating.blocking +=
+				this.synergyFactor * this.team[t].synergy.def;
+		}
+	}
+
+	override updateSynergy() {
+		for (const t of teamNums) {
+			// Count all the *fractional* skills of the active players on a team (including duplicates)
+			const skillsCount = {
+				"3": 0,
+				A: 0,
+				B: 0,
+				Di: 0,
+				Dp: 0,
+				Po: 0,
+				Ps: 0,
+				R: 0,
+			};
+
+			for (let i = 0; i < this.numPlayersOnCourt; i++) {
+				const p = this.playersOnCourt[t][i]!;
+
+				// 1 / (1 + e^-(15 * (x - 0.61))) from 0 to 1
+				// 0.61 is not always used - keep in sync with skills.js!
+
+				skillsCount["3"] += helpers.sigmoid(
+					p.compositeRating.shootingThreePointer,
+					15,
+					0.59,
+				);
+				skillsCount.A += helpers.sigmoid(
+					p.compositeRating.athleticism,
+					15,
+					0.63,
+				);
+				skillsCount.B += helpers.sigmoid(p.compositeRating.dribbling, 15, 0.68);
+				skillsCount.Di += helpers.sigmoid(
+					p.compositeRating.defenseInterior,
+					15,
+					0.57,
+				);
+				skillsCount.Dp += helpers.sigmoid(
+					p.compositeRating.defensePerimeter,
+					15,
+					0.61,
+				);
+				skillsCount.Po += helpers.sigmoid(
+					p.compositeRating.shootingLowPost,
+					15,
+					0.61,
+				);
+				skillsCount.Ps += helpers.sigmoid(p.compositeRating.passing, 15, 0.63);
+				skillsCount.R += helpers.sigmoid(
+					p.compositeRating.rebounding,
+					15,
+					0.61,
+				);
+			}
+
+			// Base offensive synergy
+			this.team[t].synergy.off = 0;
+			this.team[t].synergy.off += 5 * helpers.sigmoid(skillsCount["3"], 3, 2); // 5 / (1 + e^-(3 * (x - 2))) from 0 to 5
+
+			this.team[t].synergy.off +=
+				3 * helpers.sigmoid(skillsCount.B, 15, 0.75) +
+				helpers.sigmoid(skillsCount.B, 5, 1.75); // 3 / (1 + e^-(15 * (x - 0.75))) + 1 / (1 + e^-(5 * (x - 1.75))) from 0 to 5
+
+			this.team[t].synergy.off +=
+				3 * helpers.sigmoid(skillsCount.Ps, 15, 0.75) +
+				helpers.sigmoid(skillsCount.Ps, 5, 1.75) +
+				helpers.sigmoid(skillsCount.Ps, 5, 2.75); // 3 / (1 + e^-(15 * (x - 0.75))) + 1 / (1 + e^-(5 * (x - 1.75))) + 1 / (1 + e^-(5 * (x - 2.75))) from 0 to 5
+
+			this.team[t].synergy.off += helpers.sigmoid(skillsCount.Po, 15, 0.75); // 1 / (1 + e^-(15 * (x - 0.75))) from 0 to 5
+
+			this.team[t].synergy.off +=
+				helpers.sigmoid(skillsCount.A, 15, 1.75) +
+				helpers.sigmoid(skillsCount.A, 5, 2.75); // 1 / (1 + e^-(15 * (x - 1.75))) + 1 / (1 + e^-(5 * (x - 2.75))) from 0 to 5
+
+			this.team[t].synergy.off /= 17; // Punish teams for not having multiple perimeter skills
+
+			const perimFactor =
+				helpers.bound(
+					Math.sqrt(1 + skillsCount.B + skillsCount.Ps + skillsCount["3"]) - 1,
+					0,
+					2,
+				) / 2; // Between 0 and 1, representing the perimeter skills
+
+			this.team[t].synergy.off *= 0.5 + 0.5 * perimFactor; // Defensive synergy
+
+			this.team[t].synergy.def = 0;
+			this.team[t].synergy.def += helpers.sigmoid(skillsCount.Dp, 15, 0.75); // 1 / (1 + e^-(15 * (x - 0.75))) from 0 to 5
+
+			this.team[t].synergy.def += 2 * helpers.sigmoid(skillsCount.Di, 15, 0.75); // 2 / (1 + e^-(15 * (x - 0.75))) from 0 to 5
+
+			this.team[t].synergy.def +=
+				helpers.sigmoid(skillsCount.A, 5, 2) +
+				helpers.sigmoid(skillsCount.A, 5, 3.25); // 1 / (1 + e^-(5 * (x - 2))) + 1 / (1 + e^-(5 * (x - 3.25))) from 0 to 5
+
+			this.team[t].synergy.def /= 6; // Rebounding synergy
+
+			this.team[t].synergy.reb = 0;
+			this.team[t].synergy.reb +=
+				helpers.sigmoid(skillsCount.R, 15, 0.75) +
+				helpers.sigmoid(skillsCount.R, 5, 1.75); // 1 / (1 + e^-(15 * (x - 0.75))) + 1 / (1 + e^-(5 * (x - 1.75))) from 0 to 5
+
+			this.team[t].synergy.reb /= 4;
+		}
+	}
+}

--- a/src/worker/core/GameSim.basketball/performance.test.ts
+++ b/src/worker/core/GameSim.basketball/performance.test.ts
@@ -1,0 +1,170 @@
+import { assert, beforeAll, test } from "vitest";
+// @ts-expect-error Node-only test; the worker tsconfig excludes Node types.
+import process from "node:process";
+import { DEFAULT_LEVEL } from "../../../common/budgetLevels.ts";
+import { PHASE } from "../../../common/constants.ts";
+import { range } from "../../../common/utils.ts";
+import { resetCache, resetG } from "../../../test/helpers.ts";
+import { g, helpers } from "../../util/index.ts";
+import { player, team } from "../index.ts";
+import loadTeams from "../game/loadTeams.ts";
+import GameSim from "./index.ts";
+import ReferenceGameSim from "./performance.reference.ts";
+
+const seededRandom = (seed: number) => () => {
+	seed = (Math.imul(seed, 1664525) + 1013904223) | 0;
+	return (seed >>> 0) / 4294967296;
+};
+
+let templates: Awaited<ReturnType<typeof loadTeams>>;
+beforeAll(async () => {
+	const originalRandom = Math.random;
+	Math.random = seededRandom(12345);
+	try {
+		resetG();
+		g.setWithoutSavingToDB("season", 2013);
+		const teams = helpers.getTeamsDefault().slice(0, 2);
+		await resetCache({
+			players: [0, 1].flatMap((tid) =>
+				range(15).map(() =>
+					player.generate(tid, 25, 2010, true, DEFAULT_LEVEL),
+				),
+			),
+			teams: teams.map(team.generate),
+			teamSeasons: teams.map((t) => team.genSeasonRow(t)),
+			teamStats: teams.map((t) => team.genStatsRow(t.tid)),
+		});
+		templates = await loadTeams([0, 1], {});
+	} finally {
+		Math.random = originalRandom;
+	}
+});
+
+const createGame = (
+	Class: typeof GameSim,
+	neutralSite = false,
+	doPlayByPlay = false,
+) => {
+	const teams = structuredClone(templates);
+	return new Class({
+		gid: 0,
+		teams: [teams[0], teams[1]],
+		baseInjuryRate: 0.000125,
+		doPlayByPlay,
+		homeCourtFactor: 1,
+		allStarGame: false,
+		neutralSite,
+	});
+};
+
+test("optimizations preserve complete seeded games across court and playoff settings", () => {
+	const originalRandom = Math.random;
+	try {
+		for (const phase of [PHASE.REGULAR_SEASON, PHASE.PLAYOFFS]) {
+			g.setWithoutSavingToDB("phase", phase);
+			for (const neutralSite of [false, true]) {
+				for (let seed = 1; seed <= 20; seed++) {
+					Math.random = seededRandom(seed);
+					const expected = createGame(
+						ReferenceGameSim,
+						neutralSite,
+						seed <= 2,
+					).run();
+					Math.random = seededRandom(seed);
+					const actual = createGame(GameSim, neutralSite, seed <= 2).run();
+					assert.deepEqual(
+						actual,
+						expected,
+						`phase=${phase}, neutral=${neutralSite}, seed=${seed}`,
+					);
+				}
+			}
+		}
+	} finally {
+		Math.random = originalRandom;
+		g.setWithoutSavingToDB("phase", PHASE.REGULAR_SEASON);
+	}
+}, 60000);
+
+test.each([1, 3, 6])(
+	"preserves games with %i players on court and Elam endings",
+	(numPlayers) => {
+		const originalRandom = Math.random;
+		const originalElam = g.get("elam");
+		const originalNumPlayers = g.get("numPlayersOnCourt");
+		try {
+			g.setWithoutSavingToDB("numPlayersOnCourt", numPlayers);
+			g.setWithoutSavingToDB("elam", true);
+			for (let seed = 1; seed <= 10; seed++) {
+				Math.random = seededRandom(seed);
+				const expected = createGame(ReferenceGameSim).run();
+				Math.random = seededRandom(seed);
+				assert.deepEqual(createGame(GameSim).run(), expected);
+			}
+		} finally {
+			Math.random = originalRandom;
+			g.setWithoutSavingToDB("elam", originalElam);
+			g.setWithoutSavingToDB("numPlayersOnCourt", originalNumPlayers);
+		}
+	},
+	60000,
+);
+
+test("home-court adjustments invalidate cached skills", () => {
+	const game = createGame(GameSim, true);
+	const reference = createGame(ReferenceGameSim, true);
+	for (const factor of [1, 1.1, 0.9]) {
+		game.homeCourtAdvantage(factor);
+		reference.homeCourtAdvantage(factor);
+		game.updateSynergy();
+		reference.updateSynergy();
+		assert.deepEqual(
+			game.team.map((t) => t.synergy),
+			reference.team.map((t) => t.synergy),
+		);
+	}
+});
+
+// Optional, reproducible game-engine benchmark. This excludes the league DB,
+// UI, draft, and offseason; do not interpret it as full-season wall time.
+test.skipIf(!process.env.BBGM_BENCHMARK)(
+	"benchmark 1,230 games",
+	() => {
+		const originalRandom = Math.random;
+		const samples = { reference: [] as number[], optimized: [] as number[] };
+		const run = (Class: typeof GameSim, count: number) => {
+			const start = performance.now();
+			for (let seed = 1; seed <= count; seed++) {
+				Math.random = seededRandom(seed);
+				createGame(Class).run();
+			}
+			return performance.now() - start;
+		};
+		try {
+			run(ReferenceGameSim, 100);
+			run(GameSim, 100);
+			for (let round = 0; round < 3; round++) {
+				for (const key of round % 2
+					? (["optimized", "reference"] as const)
+					: (["reference", "optimized"] as const)) {
+					samples[key].push(
+						run(key === "reference" ? ReferenceGameSim : GameSim, 1230),
+					);
+				}
+			}
+			const median = (values: number[]) =>
+				[...values].sort((a, b) => a - b)[1]!;
+			process.stdout.write(
+				JSON.stringify({
+					gamesPerSample: 1230,
+					samplesMs: samples,
+					elapsedTimeReductionPercent:
+						100 * (1 - median(samples.optimized) / median(samples.reference)),
+				}) + "\n",
+			);
+		} finally {
+			Math.random = originalRandom;
+		}
+	},
+	180000,
+);

--- a/src/worker/db/Cache.test.ts
+++ b/src/worker/db/Cache.test.ts
@@ -48,3 +48,29 @@ describe("get", () => {
 		assert.strictEqual(p.pid, p2.pid);
 	});
 });
+
+describe("putAll", () => {
+	test("stores multiple objects and returns their IDs", async () => {
+		const p = (await idb.cache.players.getAll())[0];
+		assert(p);
+		const p2 = {
+			...p,
+			pid: p.pid + 100000,
+			firstName: "Batch",
+			lastName: "Test",
+		};
+
+		p.firstName = "Updated";
+		const ids = await idb.cache.players.putAll([p, p2]);
+
+		assert.deepEqual(ids, [p.pid, p2.pid]);
+		assert.strictEqual(
+			(await idb.cache.players.get(p.pid))?.firstName,
+			"Updated",
+		);
+		assert.strictEqual(
+			(await idb.cache.players.get(p2.pid))?.firstName,
+			"Batch",
+		);
+	});
+});

--- a/src/worker/db/Cache.ts
+++ b/src/worker/db/Cache.ts
@@ -186,6 +186,10 @@ class StoreAPI<Input, Output, ID extends string | number> {
 		return this.cache._put(this.store, obj) as any;
 	}
 
+	putAll(objs: Input[]): Promise<ID[]> {
+		return this.cache._putAll(this.store, objs) as any;
+	}
+
 	delete(id: ID): Promise<void> {
 		return this.cache._delete(this.store, id);
 	}
@@ -967,12 +971,7 @@ class Cache {
 		return output;
 	}
 
-	async _storeObj(
-		type: "add" | "put",
-		store: Store,
-		obj: any,
-	): Promise<number | string> {
-		await this._waitForStatus("full");
+	_storeObjRaw(type: "add" | "put", store: Store, obj: any): number | string {
 		const pk = this.storeInfos[store].pk;
 
 		if (Object.hasOwn(obj, pk)) {
@@ -1018,12 +1017,26 @@ class Cache {
 		return obj[pk];
 	}
 
+	async _storeObj(
+		type: "add" | "put",
+		store: Store,
+		obj: any,
+	): Promise<number | string> {
+		await this._waitForStatus("full");
+		return this._storeObjRaw(type, store, obj);
+	}
+
 	_add(store: Store, obj: any): Promise<number | string> {
 		return this._storeObj("add", store, obj);
 	}
 
 	_put(store: Store, obj: any): Promise<number | string> {
 		return this._storeObj("put", store, obj);
+	}
+
+	async _putAll(store: Store, objs: any[]): Promise<(number | string)[]> {
+		await this._waitForStatus("full");
+		return objs.map((obj) => this._storeObjRaw("put", store, obj));
 	}
 
 	async _delete(store: Store, id: number | string) {

--- a/src/worker/util/advStatsSave.test.ts
+++ b/src/worker/util/advStatsSave.test.ts
@@ -1,0 +1,47 @@
+import { assert, beforeAll, test } from "vitest";
+import { DEFAULT_LEVEL } from "../../common/budgetLevels.ts";
+import { resetCache, resetG } from "../../test/helpers.ts";
+import { player } from "../core/index.ts";
+import { idb } from "../db/index.ts";
+import advStatsSave from "./advStatsSave.ts";
+
+beforeAll(async () => {
+	resetG();
+	const players = [
+		player.generate(0, 25, 2010, true, DEFAULT_LEVEL),
+		player.generate(1, 25, 2010, true, DEFAULT_LEVEL),
+	];
+	for (const p of players) {
+		player.addStatsRow(p, 2013, false);
+	}
+	await resetCache({ players });
+});
+
+test("matches calculated stats to players by PID and saves them in one batch", async () => {
+	const playersRaw = await idb.cache.players.getAll();
+	const [p1, p2] = playersRaw;
+	assert(p1);
+	assert(p2);
+
+	await advStatsSave([{ pid: p2.pid }, { pid: p1.pid }], playersRaw, {
+		per: [22, 11],
+		dws: [Number.NaN, 3],
+	});
+
+	assert.strictEqual(
+		(await idb.cache.players.get(p1.pid))?.stats.at(-1)?.per,
+		11,
+	);
+	assert.strictEqual(
+		(await idb.cache.players.get(p1.pid))?.stats.at(-1)?.dws,
+		3,
+	);
+	assert.strictEqual(
+		(await idb.cache.players.get(p2.pid))?.stats.at(-1)?.per,
+		22,
+	);
+	assert.strictEqual(
+		(await idb.cache.players.get(p2.pid))?.stats.at(-1)?.dws,
+		0,
+	);
+});

--- a/src/worker/util/advStatsSave.ts
+++ b/src/worker/util/advStatsSave.ts
@@ -7,25 +7,28 @@ const advStatsSave = async (
 	updatedStats: Record<string, number[] | number[][]>,
 ) => {
 	const keys = Object.keys(updatedStats);
-	await Promise.all(
-		players.map(async ({ pid }, i) => {
-			const p = playersRaw.find((p2) => p2.pid === pid);
+	const playersRawByPid = new Map(playersRaw.map((p) => [p.pid, p]));
+	const playersToSave: Player[] = [];
 
-			if (p) {
-				const ps = p.stats.at(-1);
+	for (const [i, { pid }] of players.entries()) {
+		const p = playersRawByPid.get(pid);
 
-				if (ps) {
-					for (const key of keys) {
-						if (!Number.isNaN(updatedStats[key]![i])) {
-							ps[key] = updatedStats[key]![i];
-						}
+		if (p) {
+			const ps = p.stats.at(-1);
+
+			if (ps) {
+				for (const key of keys) {
+					if (!Number.isNaN(updatedStats[key]![i])) {
+						ps[key] = updatedStats[key]![i];
 					}
-
-					await idb.cache.players.put(p);
 				}
+
+				playersToSave.push(p);
 			}
-		}),
-	);
+		}
+	}
+
+	await idb.cache.players.putAll(playersToSave);
 };
 
 export default advStatsSave;


### PR DESCRIPTION
## Summary

Cache basketball player synergy contributions, calculate six team composites in one pass, reuse weighted-selection buffers, streamline playing-time bookkeeping, and skip inactive play-by-play logging work.

Advanced-stat saving now indexes players by PID and batches cache writes, avoiding repeated linear searches and per-player readiness awaits.

## Behavior and validation

- Preserve multiplication and summation order in optimized team-rating calculations.
- Invalidate cached synergy contributions after home-court adjustments.
- Add regression coverage for playing time, player selection, cache writes, advanced-stat saves, and complete game results.
- 110 seeded complete games match the reference methods, including regular-season/playoff settings, neutral/home courts, selected play-by-play runs, and alternate lineup sizes with Elam endings.
- Rebased on upstream master at 9e0de55c615e301512862bb188cc0f6e77bb6a1e.
- With frozen-lockfile dependencies: lint passed, 379 non-browser tests passed (13 skipped), and the basketball production build passed.
- Browser suite was interrupted after repeated unhandled errors in advStats.baseball.ts (missing stats.gpF) and allStar/create.ts (missing currentStats.pssYds). The cause has not been isolated or checked against clean upstream. This PR is a draft pending clean browser validation.

## Benchmark

Optional Node.js benchmark: 1,230 games per sample, identical generated rosters and random seeds, warmup, and three alternating reference/optimized samples.

Median elapsed time: 1,994.86 ms reference versus 1,393.02 ms optimized, approximately 30.17% less elapsed time. This isolates the synergy/team-composite changes against the previously optimized local engine; it does not benchmark the complete PR against unmodified upstream.

Includes roster copying and game construction, but excludes database saves, advanced-stat processing, UI updates, scheduling, and offseason development. This is not a full-season browser speedup claim.

```sh
BBGM_BENCHMARK=1 pnpm exec vitest run --project basketball src/worker/core/GameSim.basketball/performance.test.ts
```
